### PR TITLE
scheduler-runner: Building block for scheduler-runner

### DIFF
--- a/checkmk_extensions/agent/scheduler_runner.ps1
+++ b/checkmk_extensions/agent/scheduler_runner.ps1
@@ -1,0 +1,72 @@
+function Main {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$PathPIDFile
+    )
+
+    try {
+        TerminateProcess -PathPIDFile $PathPIDFile
+
+        while ($true) {
+            try {
+                $Process = Get-Process -Id (Get-Content -Path $PathPIDFile -ErrorAction Stop) -ErrorAction Stop
+            } catch {
+                $Process = $null
+            }
+
+            if ($null -eq $Process) {
+                $Process = StartProcessAndPersistPid -Executable $Executable -Arguments $Arguments -PathPIDFile $PathPIDFile
+            }
+            else {
+                Start-Sleep -Seconds 20
+            }
+        }
+    } catch {
+        Write-Host "An error occurred: $_"
+        TerminateProcess -PathPIDFile $PathPIDFile
+    }
+}
+function StartProcessAndPersistPid {
+    [CmdletBinding()]
+    [OutputType([System.Diagnostics.Process])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Executable,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$PathPIDFile
+    )
+
+    $Process = Start-Process -FilePath $Executable -ArgumentList $Arguments -PassThru -ErrorAction Stop
+    $Process.Id | Set-Content -Path $PathPIDFile
+    return $Process
+}
+
+function TerminateProcess {
+    # This will stop the process with the PID from the file
+    # Also, it will delete the existing file containing the PID
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PathPIDFile
+    )
+
+    if (Test-Path -Path $PathPIDFile -PathType Leaf) {
+        $OtherPid = (Get-Content -Path $PathPIDFile -ErrorAction SilentlyContinue) -as [int]
+        if ($OtherPid -and (Get-Process -Id $OtherPid -ErrorAction SilentlyContinue)) {
+            Stop-Process -Id $OtherPid -Force -ErrorAction SilentlyContinue
+        }
+        # Delete file containing PID
+        Remove-Item -Path $PathPIDFile -ErrorAction SilentlyContinue
+    }
+}
+
+try {
+    Main -Executable "powershell.exe" -Arguments "-File path/to/powershell_script" -PathPIDFile "current_pid.txt"
+} finally {
+    TerminateProcess -PathPIDFile "current_pid.txt"
+}


### PR DESCRIPTION
I used what you sent me as the template and did some modification.

I added some error handling, but I am not sure which -ErrorAction we should prefer at this point. I went for the "SilentlyContinue", but the "Ignore" option is good as well. 
This is the difference:
- SilentlyContinue: This value suppresses the error messages and continues executing the command. It is represented by the numeric value 0
- Ignore: This value ignores non-terminating errors and continues executing the command. However, it records the error in the $Error automatic variable. It is represented by the numeric value 3

I will play around more and try to connect it with the existing code that Simon wrote.