### PR TITLE
scheduler_runner: Add function to read RCC value from config file

### DIFF
--- a/checkmk_extensions/agent/scheduler_runner.ps1
+++ b/checkmk_extensions/agent/scheduler_runner.ps1
@@ -1,0 +1,68 @@
+function GetContentFromConfigFile {
+    [CmdletBinding()]
+
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$configFilePath
+    )
+
+    if (-not (Test-Path -Path $configFilePath -PathType Leaf)) {
+        # File doesn't exist, so we exit with message
+        Write-Error -Message "The file is not available at: $configFilePath"
+        Exit 1
+    } else {
+        # Config file is available
+        $configContent = Get-Content -Path $configFilePath
+        return $configContent
+    }
+}
+
+function DetermineRCCValueFromConfig {
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$rccValueFromConfigFile
+    )
+
+    if ($rccValueFromConfigFile -eq "NO") {
+        # The defined value for RCC in the config file is NO
+        return $false
+    } elseif ($rccValueFromConfigFile -eq "YES") {
+        # The defined value for RCC in the config file is YES
+        return $true
+    } else {
+        # Unknown value defined
+        Write-Error "The defined value for the RCC is not valid. It must be YES or NO, but it is: $rccValueFromConfigFile" -Category InvalidArgument
+        Exit 1
+    }
+}
+function RunRCCOrNot {
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$configFilePath
+    )
+
+    $configContent = GetContentFromConfigFile $configFilePath
+    foreach ($line in $configContent) {
+        # Skip empty lines and comments (lines starting with '#')
+        if (-not [string]::IsNullOrWhiteSpace($line) -and -not $line.StartsWith("#")) {
+            $match = $line | Select-String -Pattern "RCC=(.+)$"
+
+            if (-not $match) {
+                # The RCC value is not defined, so we assume it should not run in RCC
+                $run_in_rcc = $false
+            } else {
+                # The RCC value is defined
+                $run_in_rcc = DetermineRCCValueFromConfig -rccValueFromConfigFile $match.Matches[0].Groups[1].Value
+            }
+        }
+    }
+
+    return $run_in_rcc
+}
+

--- a/robotmk/src/robotmk/context/suite/strategies/run.py
+++ b/robotmk/src/robotmk/context/suite/strategies/run.py
@@ -63,8 +63,6 @@ class Runner:
 
         # TODO: log console output? Save it anyway because a a fatal RF error must be tracable.
         # RCC does not re.execute...
-        if getattr(self.target, "attempt", None) is None:
-            self.target.attempt = 1
         return result
 
     def exec_post(self) -> Result:

--- a/robotmk/src/robotmk/context/suite/strategies/run.py
+++ b/robotmk/src/robotmk/context/suite/strategies/run.py
@@ -27,7 +27,7 @@ class Runner:
     def __init__(self, target) -> None:
         self.target = target
 
-    def run(self, env: UserDict) -> int:
+    def run(self, env: UserDict) -> tuple[int, Result]:
         """Template method which bundles the linked methods to run.
 
         The concrete strategy selectivly overrides the methods to implement."""
@@ -35,7 +35,7 @@ class Runner:
         main = self.exec_main(env)
         post = self.exec_post()
         return_code = max(pre.returncode, main.returncode, post.returncode)
-        return return_code
+        return return_code, main
 
     def run_subprocess(self, command, environ) -> Result:
         """If command was given, run the subprocess and return the result object."""
@@ -65,7 +65,6 @@ class Runner:
         # RCC does not re.execute...
         if getattr(self.target, "attempt", None) is None:
             self.target.attempt = 1
-        self.target.console_results[self.target.attempt] = asdict(result)
         return result
 
     def exec_post(self) -> Result:

--- a/robotmk/src/robotmk/context/suite/target/local/abstract.py
+++ b/robotmk/src/robotmk/context/suite/target/local/abstract.py
@@ -41,6 +41,7 @@ class LocalTarget(Target):
         self.run_strategy = create_runstrategy(self)
         # list of subprocess' results and console output
         self.console_results = {}
+        self.attempt: int | None = None
 
     @abstractmethod
     def run(self):

--- a/robotmk/src/robotmk/context/suite/target/local/abstract.py
+++ b/robotmk/src/robotmk/context/suite/target/local/abstract.py
@@ -37,8 +37,6 @@ class LocalTarget(Target):
         self.config = config
         self.logger = logger
         self.path = _create_suite_path(config)
-        # TODO: run strategy should not be set in init, because output() always reads results from filesystem
-        self.run_strategy = create_runstrategy(self)
         # list of subprocess' results and console output
         self.console_results = {}
         self.attempt: int | None = None

--- a/robotmk/src/robotmk/context/suite/target/local/rcc.py
+++ b/robotmk/src/robotmk/context/suite/target/local/rcc.py
@@ -2,6 +2,7 @@
 
 import math
 import os
+from dataclasses import asdict
 
 from robotmk.config.config import Config
 from robotmk.logger import RobotmkLogger
@@ -105,7 +106,9 @@ class RCCTarget(LocalTarget):
             pass
         else:
             run_env = self.prepare_environment()
-            self.rc = self.run_strategy.run(env=run_env)
+            (return_code, result) = self.run_strategy.run(env=run_env)
+            self.target.console_results[self.target.attempt] = asdict(result)
+            self.rc = return_code
 
     @property
     def is_rcc_compatible(self):

--- a/robotmk/src/robotmk/context/suite/target/local/rcc.py
+++ b/robotmk/src/robotmk/context/suite/target/local/rcc.py
@@ -107,7 +107,7 @@ class RCCTarget(LocalTarget):
         else:
             run_env = self.prepare_environment()
             (return_code, result) = self.run_strategy.run(env=run_env)
-            self.target.console_results[self.target.attempt] = asdict(result)
+            self.target.console_results[1] = asdict(result)
             self.rc = return_code
 
     @property

--- a/robotmk/src/robotmk/context/suite/target/local/rcc.py
+++ b/robotmk/src/robotmk/context/suite/target/local/rcc.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import asdict
 
 from robotmk.config.config import Config
+from robotmk.context.suite.strategies import create_runstrategy
 from robotmk.logger import RobotmkLogger
 
 from .abstract import LocalTarget
@@ -106,7 +107,7 @@ class RCCTarget(LocalTarget):
             pass
         else:
             run_env = self.prepare_environment()
-            (return_code, result) = self.run_strategy.run(env=run_env)
+            (return_code, result) = create_runstrategy(self).run(env=run_env)
             self.target.console_results[1] = asdict(result)
             self.rc = return_code
 

--- a/robotmk/src/robotmk/context/suite/target/local/robotframework/retry.py
+++ b/robotmk/src/robotmk/context/suite/target/local/robotframework/retry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from robot.rebot import rebot
 
+from robotmk.context.suite.strategies import create_runstrategy
 from robotmk.context.suite.target.local.abstract import LocalTarget
 
 
@@ -47,7 +48,7 @@ class RetryStrategy(ABC):
             self.target.attempt = attempt
 
             # TODO: log the cli args
-            (return_code, result) = self.target.run_strategy.run(os.environ)
+            (return_code, result) = create_runstrategy(self.target).run(os.environ)
             self.target.console_results[self.target.attempt] = asdict(result)
             # TODO: Logging
             # if rc > 250:


### PR DESCRIPTION
This is supposed to read the specified configuration file and see if there is the RCC parameter defined. I assumed that it will be YES and NO, but we can easily change that depending on the bakery rule. Also, if the RCC paramater is not defined/present in the config file, I assume that the process should not be started in RCC.

As the final output it will return either True or False, meaning that the process should be started in RCC or shouldn't.

In case the file is not present or the RCC parameter is not defined or the value is not YES or NO, it exit with code 1.