### PR TITLE
Add RCCer

### DIFF
--- a/v2/src/rccer.py
+++ b/v2/src/rccer.py
@@ -1,0 +1,44 @@
+import dataclasses
+import pathlib
+import subprocess
+
+import runner
+
+
+@dataclasses.dataclass(frozen=True)
+class _RCCBuilder:
+    rcc_binary: str
+    robot_yaml: pathlib.Path
+
+    def create_command(self) -> str:
+        return f"{self.rcc_binary} holotree variables --json -r {self.robot_yaml}"
+
+
+@dataclasses.dataclass(frozen=True)
+class _RCCRunner:
+    rcc_binary: str
+    robot_yaml: pathlib.Path
+    command: str
+
+    def create_command(self) -> str:
+        return f"{self.rcc_binary} task script -r {self.robot_yaml} -- {self.command}"
+
+
+def _execute(target: _RCCRunner | _RCCBuilder) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        target.create_command(),
+        shell=True,
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+
+def _create_rcc_runners(
+    rcc_binary: str, robot_yaml: pathlib.Path, example: runner.RetrySpec
+) -> list[_RCCRunner]:
+    commands = runner.create_commands(example)
+    return [
+        _RCCRunner(rcc_binary=rcc_binary, robot_yaml=robot_yaml, command=command)
+        for command in commands
+    ]

--- a/v2/src/runner.py
+++ b/v2/src/runner.py
@@ -33,7 +33,7 @@ class _Variant:
 
 
 @dataclasses.dataclass(frozen=True)
-class _RetrySpec:
+class RetrySpec:
     id_: uuid.UUID
     python_executable: pathlib.Path
     robot_target: pathlib.Path
@@ -57,7 +57,7 @@ def _create_command(spec: _RunnerSpec) -> str:
     )
 
 
-def _create_commands(spec: _RetrySpec) -> Sequence[str]:
+def create_commands(spec: RetrySpec) -> Sequence[str]:
     commands = []
     for i, variant in enumerate(spec.schedule):
         runner_cfg = _RunnerSpec(


### PR DESCRIPTION
The `_RCCBuilder` allows creation of conda environments via the rcc tool.  The `_RCCRunner` allows executing a command inside of the space, which was built via RCC. Provisionally, we supply commands from the RetrySpec to RCCRunners.

CMK-14087