### PR TITLE
python_executable: disallow configuration

### DIFF
--- a/v2/robotmk/scheduler.py
+++ b/v2/robotmk/scheduler.py
@@ -29,7 +29,6 @@ class _RCC(BaseModel, frozen=True):
 
 class _SuiteConfig(BaseModel, frozen=True):  # pylint: disable=too-few-public-methods
     execution_interval_seconds: int
-    python_executable: pathlib.Path
     robot_target: pathlib.Path
     working_directory: pathlib.Path
     variants: Sequence[Variant]
@@ -66,7 +65,6 @@ class _SuiteRetryRunner:  # pylint: disable=too-few-public-methods
 
         retry_spec = RetrySpec(
             id_=uuid4(),
-            python_executable=self._config.python_executable,
             robot_target=self._config.robot_target,
             working_directory=self._config.working_directory,
             schedule=self._config.variants,
@@ -79,10 +77,10 @@ class _SuiteRetryRunner:  # pylint: disable=too-few-public-methods
             return  # Untested
 
         final_output = retry_spec.outputdir() / "merged.xml"
+
         _process = subprocess.run(
             shlex.split(
                 create_merge_command(
-                    python_executable=self._config.python_executable,
                     attempt_outputs=outputs,
                     final_output=final_output,
                 )

--- a/v2/tests/test_runner.py
+++ b/v2/tests/test_runner.py
@@ -8,7 +8,6 @@ from robotmk import runner
 
 def test_create_command_complete() -> None:
     spec = runner._RunnerSpec(
-        python_executable=pathlib.Path("/usr/bin/python3"),
         robot_target=pathlib.Path("~/suite/calculator.robot"),
         outputdir=pathlib.Path("/tmp/outputdir/"),
         output_name="0",
@@ -18,7 +17,7 @@ def test_create_command_complete() -> None:
         retry_strategy=runner.RetryStrategy.COMPLETE,
     )
     expected = (
-        "/usr/bin/python3 -m robot --outputdir=/tmp/outputdir --output=/tmp/outputdir/0.xml "
+        "python -m robot --outputdir=/tmp/outputdir --output=/tmp/outputdir/0.xml "
         "~/suite/calculator.robot"
     )
     assert spec.command() == expected
@@ -26,7 +25,6 @@ def test_create_command_complete() -> None:
 
 def test_create_command_incremental() -> None:
     spec = runner._RunnerSpec(
-        python_executable=pathlib.Path("/usr/bin/python3"),
         robot_target=pathlib.Path("~/suite/calculator.robot"),
         outputdir=pathlib.Path("/tmp/outputdir/"),
         output_name="1",
@@ -36,7 +34,7 @@ def test_create_command_incremental() -> None:
         retry_strategy=runner.RetryStrategy.INCREMENTAL,
     )
     expected = (
-        "/usr/bin/python3 -m robot --argumentfile=~/suite/retry_arguments "
+        "python -m robot --argumentfile=~/suite/retry_arguments "
         "--rerunfailed=/tmp/outputdir/0.xml --outputdir=/tmp/outputdir "
         "--output=/tmp/outputdir/1.xml ~/suite/calculator.robot"
     )
@@ -47,7 +45,6 @@ def test_create_attempts() -> None:
     attempts = runner.create_attempts(
         runner.RetrySpec(
             id_=uuid.UUID("383783f4-1d02-43b1-9d6f-205f4d492d95"),
-            python_executable=pathlib.Path("/usr/bin/python3"),
             robot_target=pathlib.Path("~/suite/calculator.robot"),
             working_directory=pathlib.Path("/tmp/outputdir/"),
             schedule=[
@@ -68,7 +65,7 @@ def test_create_attempts() -> None:
             output=pathlib.Path(
                 "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml"
             ),
-            command="/usr/bin/python3 -m robot "
+            command="python -m robot "
             "--outputdir=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95 "
             "--output=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml "
             "~/suite/calculator.robot",
@@ -77,7 +74,7 @@ def test_create_attempts() -> None:
             output=pathlib.Path(
                 "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/1.xml"
             ),
-            command="/usr/bin/python3 -m robot --variablefile=~/suite/retry.yaml "
+            command="python -m robot --variablefile=~/suite/retry.yaml "
             "--rerunfailed=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml "
             "--outputdir=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95 "
             "--output=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/1.xml "
@@ -88,13 +85,12 @@ def test_create_attempts() -> None:
 
 def test_create_merge_command() -> None:
     assert runner.create_merge_command(
-        python_executable=pathlib.Path("/usr/bin/python3"),
         attempt_outputs=[
             pathlib.Path("/tmp/outputdir/0.xml"),
             pathlib.Path("/tmp/outputdir/1.xml"),
         ],
         final_output=pathlib.Path("/tmp/outputdir/merged.xml"),
     ) == (
-        "/usr/bin/python3 -m robot.rebot --output=/tmp/outputdir/merged.xml --report=NONE "
+        "python -m robot.rebot --output=/tmp/outputdir/merged.xml --report=NONE "
         "--log=NONE /tmp/outputdir/0.xml /tmp/outputdir/1.xml"
     )


### PR DESCRIPTION
Reduces test bloat, and prevents accidently exposing the executable via the configuration (until we have a specification).