### PR TITLE
Make pre-push git hook more flexible

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,13 +2,17 @@
 
 set -e
 
-VALID_BRANCH_REGEX="^(master$|dev\/.+)"
+VALID_BRANCH_REGEX="(master$|dev\/.+)"
+VALID_REF_REGEX="^refs\/heads\/${VALID_BRANCH_REGEX}"
 
-if [[ ! $(git rev-parse --abbrev-ref HEAD) =~ $VALID_BRANCH_REGEX ]]
-then
-    echo "Branch names should follow this pattern: ${VALID_BRANCH_REGEX}."
-    exit 1
-fi
+while read -r _local_ref _local_oid remote_ref _remote_oid
+do
+    if [[ ! "${remote_ref}" =~ $VALID_REF_REGEX ]]
+    then
+        echo "Branch names should follow this pattern: ${VALID_BRANCH_REGEX}."
+        exit 1
+    fi
+done
 
 topdir="$(git rev-parse --show-toplevel)"
 "${topdir}"/ci check-all


### PR DESCRIPTION
We follow the example provided in
/usr/share/git-core/templates/hooks/pre-push.sample

This change for example allows for pushing via
`git push origin HEAD:refs/heads/dev/...`
while rebasing to create PRs for commits which are not at the top of the dependency chain.