### PR TITLE
Move logic from `runner._RunnerSpec` to `runner.Attempt`

### DIFF
--- a/v2/robotmk/runner.py
+++ b/v2/robotmk/runner.py
@@ -4,7 +4,7 @@ import dataclasses
 import enum
 import pathlib
 import uuid
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Final
 
 PYTHON_EXECUTABLE: Final = pathlib.Path("python")
@@ -13,44 +13,6 @@ PYTHON_EXECUTABLE: Final = pathlib.Path("python")
 class RetryStrategy(enum.Enum):
     INCREMENTAL = "incremental"
     COMPLETE = "complete"
-
-
-@dataclasses.dataclass(frozen=True)
-class _RunnerSpec:
-    robot_target: pathlib.Path
-    outputdir: pathlib.Path
-    output_name: str
-    previous_output: pathlib.Path | None
-    variablefile: pathlib.Path | None
-    argumentfile: pathlib.Path | None
-    retry_strategy: RetryStrategy
-
-    def output(self) -> pathlib.Path:
-        return self.outputdir / f"{self.output_name}.xml"
-
-    def command(self) -> list[str]:
-        robot_command = [str(PYTHON_EXECUTABLE), "-m", "robot"]
-        if self.variablefile is not None:
-            robot_command.append(f"--variablefile={self.variablefile}")
-        if self.argumentfile is not None:
-            robot_command.append(f"--argumentfile={self.argumentfile}")
-        if self.retry_strategy is RetryStrategy.INCREMENTAL and self.previous_output:
-            robot_command.append(f"--rerunfailed={self.previous_output}")
-        return robot_command + [
-            f"--outputdir={self.outputdir}",
-            f"--output={self.output()}",
-            str(self.robot_target),
-        ]
-
-    def _check(self) -> bool:
-        paths_to_check = [
-            self.robot_target,
-            self.outputdir,
-            self.variablefile,
-            self.argumentfile,
-            self.previous_output,
-        ]
-        return any(not path.exists() for path in paths_to_check if path is not None)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -67,38 +29,51 @@ class RetrySpec:
     variants: Sequence[Variant]
     strategy: RetryStrategy
 
-    def outputdir(self) -> pathlib.Path:
+    def output_directory(self) -> pathlib.Path:
         return self.working_directory.joinpath(self.id_.hex)
 
 
 @dataclasses.dataclass(frozen=True)
 class Attempt:
-    output: pathlib.Path
-    command: list[str]
+    output_directory: pathlib.Path
+    id_: uuid.UUID
+    index: int
+    robot_target: pathlib.Path
+    variable_file: pathlib.Path | None
+    argument_file: pathlib.Path | None
+    retry_strategy: RetryStrategy
+
+    def output_file(self) -> pathlib.Path:
+        return self._output_file(self.index)
+
+    def command(self) -> list[str]:
+        robot_command = [str(PYTHON_EXECUTABLE), "-m", "robot"]
+        if self.variable_file is not None:
+            robot_command.append(f"--variablefile={self.variable_file}")
+        if self.argument_file is not None:
+            robot_command.append(f"--argumentfile={self.argument_file}")
+        if self.retry_strategy is RetryStrategy.INCREMENTAL and self.index > 0:
+            robot_command.append(f"--rerunfailed={self._output_file(self.index - 1)}")
+        return robot_command + [
+            f"--outputdir={self.output_directory}",
+            f"--output={self.output_file()}",
+            str(self.robot_target),
+        ]
+
+    def _output_file(self, index: int) -> pathlib.Path:
+        return self.output_directory.joinpath(f"{index}.xml")
 
 
-def create_attempts(spec: RetrySpec) -> list[Attempt]:
-    attempts = []
-    previous_output = None
-
-    for i, variant in enumerate(spec.variants):
-        runner_spec = _RunnerSpec(
+def create_attempts(spec: RetrySpec) -> Iterator[Attempt]:
+    yield from (
+        Attempt(
+            output_directory=spec.output_directory(),
+            id_=spec.id_,
+            index=i,
             robot_target=spec.robot_target,
-            outputdir=spec.outputdir(),
-            output_name=str(
-                i
-            ),  # Ensure the `robot` command does not overwrite previous runs
-            previous_output=previous_output,
-            variablefile=variant.variablefile,
-            argumentfile=variant.argumentfile,
+            variable_file=variant.variablefile,
+            argument_file=variant.argumentfile,
             retry_strategy=spec.strategy,
         )
-        previous_output = runner_spec.output()
-        attempts.append(
-            Attempt(
-                output=runner_spec.output(),
-                command=runner_spec.command(),
-            )
-        )
-
-    return attempts
+        for i, variant in enumerate(spec.variants)
+    )

--- a/v2/robotmk/scheduler.py
+++ b/v2/robotmk/scheduler.py
@@ -91,7 +91,7 @@ class _SuiteRetryRunner:  # pylint: disable=too-few-public-methods
         if not outputs:
             return  # Untested
 
-        final_output = retry_spec.outputdir() / "merged.xml"
+        final_output = retry_spec.output_directory() / "merged.xml"
 
         rebot(*outputs, output=final_output, report=None, log=None)
         self._final_outputs.append(final_output)
@@ -109,9 +109,9 @@ class _SuiteRetryRunner:  # pylint: disable=too-few-public-methods
         for attempt in attempts:
             match self._session.run(attempt):
                 case ResultCode.ALL_TESTS_PASSED:
-                    outputs.append(attempt.output)
-                case ResultCode.ROBOT_COMMAND_FAILED if attempt.output.exists():
-                    outputs.append(attempt.output)
+                    outputs.append(attempt.output_file())
+                case ResultCode.ROBOT_COMMAND_FAILED if attempt.output_file().exists():
+                    outputs.append(attempt.output_file())
                     continue
             break
         return outputs

--- a/v2/robotmk/session.py
+++ b/v2/robotmk/session.py
@@ -12,7 +12,7 @@ class CurrentSession:
     def run(self, attempt: Attempt) -> ResultCode:
         return self.environment.create_result_code(
             subprocess.run(
-                self.environment.wrap_for_execution(attempt.command),
+                self.environment.wrap_for_execution(attempt.command()),
                 check=False,
                 encoding="utf-8",
             )

--- a/v2/tests/test_runner.py
+++ b/v2/tests/test_runner.py
@@ -3,99 +3,113 @@ import uuid
 
 from robotmk import runner
 
-# pylint: disable=protected-access
-
 
 def test_create_command_complete() -> None:
-    spec = runner._RunnerSpec(
+    attempt = runner.Attempt(
+        output_directory=pathlib.Path("/tmp/d9e87a17-2e68-450a-8228-624604d47b26/"),
+        id_=uuid.UUID("d9e87a17-2e68-450a-8228-624604d47b26"),
+        index=0,
         robot_target=pathlib.Path("~/suite/calculator.robot"),
-        outputdir=pathlib.Path("/tmp/outputdir/"),
-        output_name="0",
-        previous_output=None,
-        variablefile=None,
-        argumentfile=None,
+        variable_file=None,
+        argument_file=None,
         retry_strategy=runner.RetryStrategy.COMPLETE,
     )
     expected = [
         "python",
         "-m",
         "robot",
-        "--outputdir=/tmp/outputdir",
-        "--output=/tmp/outputdir/0.xml",
+        "--outputdir=/tmp/d9e87a17-2e68-450a-8228-624604d47b26",
+        "--output=/tmp/d9e87a17-2e68-450a-8228-624604d47b26/0.xml",
         "~/suite/calculator.robot",
     ]
-    assert spec.command() == expected
+    assert attempt.command() == expected
 
 
-def test_create_command_incremental() -> None:
-    spec = runner._RunnerSpec(
+def test_create_command_incremental_first() -> None:
+    attempt = runner.Attempt(
+        output_directory=pathlib.Path("/tmp/d9e87a17-2e68-450a-8228-624604d47b26/"),
+        id_=uuid.UUID("d9e87a17-2e68-450a-8228-624604d47b26"),
+        index=0,
         robot_target=pathlib.Path("~/suite/calculator.robot"),
-        outputdir=pathlib.Path("/tmp/outputdir/"),
-        output_name="1",
-        previous_output=pathlib.Path("/tmp/outputdir/0.xml"),
-        variablefile=None,
-        argumentfile=pathlib.Path("~/suite/retry_arguments"),
+        variable_file=None,
+        argument_file=None,
         retry_strategy=runner.RetryStrategy.INCREMENTAL,
     )
     expected = [
         "python",
         "-m",
         "robot",
-        "--argumentfile=~/suite/retry_arguments",
-        "--rerunfailed=/tmp/outputdir/0.xml",
-        "--outputdir=/tmp/outputdir",
-        "--output=/tmp/outputdir/1.xml",
+        "--outputdir=/tmp/d9e87a17-2e68-450a-8228-624604d47b26",
+        "--output=/tmp/d9e87a17-2e68-450a-8228-624604d47b26/0.xml",
         "~/suite/calculator.robot",
     ]
-    assert spec.command() == expected
+    assert attempt.command() == expected
+
+
+def test_create_command_incremental_second() -> None:
+    attempt = runner.Attempt(
+        output_directory=pathlib.Path("/tmp/d9e87a17-2e68-450a-8228-624604d47b26/"),
+        id_=uuid.UUID("d9e87a17-2e68-450a-8228-624604d47b26"),
+        index=1,
+        robot_target=pathlib.Path("~/suite/calculator.robot"),
+        variable_file=None,
+        argument_file=None,
+        retry_strategy=runner.RetryStrategy.INCREMENTAL,
+    )
+    expected = [
+        "python",
+        "-m",
+        "robot",
+        "--rerunfailed=/tmp/d9e87a17-2e68-450a-8228-624604d47b26/0.xml",
+        "--outputdir=/tmp/d9e87a17-2e68-450a-8228-624604d47b26",
+        "--output=/tmp/d9e87a17-2e68-450a-8228-624604d47b26/1.xml",
+        "~/suite/calculator.robot",
+    ]
+    assert attempt.command() == expected
 
 
 def test_create_attempts() -> None:
-    attempts = runner.create_attempts(
-        runner.RetrySpec(
-            id_=uuid.UUID("383783f4-1d02-43b1-9d6f-205f4d492d95"),
-            robot_target=pathlib.Path("~/suite/calculator.robot"),
-            working_directory=pathlib.Path("/tmp/outputdir/"),
-            variants=[
-                runner.Variant(
-                    variablefile=None,
-                    argumentfile=None,
-                ),
-                runner.Variant(
-                    variablefile=pathlib.Path("~/suite/retry.yaml"),
-                    argumentfile=None,
-                ),
-            ],
-            strategy=runner.RetryStrategy.INCREMENTAL,
+    attempts = list(
+        runner.create_attempts(
+            runner.RetrySpec(
+                id_=uuid.UUID("383783f4-1d02-43b1-9d6f-205f4d492d95"),
+                robot_target=pathlib.Path("~/suite/calculator.robot"),
+                working_directory=pathlib.Path("/tmp/outputdir/"),
+                variants=[
+                    runner.Variant(
+                        variablefile=None,
+                        argumentfile=None,
+                    ),
+                    runner.Variant(
+                        variablefile=pathlib.Path("~/suite/retry.yaml"),
+                        argumentfile=None,
+                    ),
+                ],
+                strategy=runner.RetryStrategy.INCREMENTAL,
+            )
         )
     )
     assert attempts == [
         runner.Attempt(
-            output=pathlib.Path(
-                "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml"
+            output_directory=pathlib.Path(
+                "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95"
             ),
-            command=[
-                "python",
-                "-m",
-                "robot",
-                "--outputdir=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95",
-                "--output=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml",
-                "~/suite/calculator.robot",
-            ],
+            id_=uuid.UUID("383783f4-1d02-43b1-9d6f-205f4d492d95"),
+            index=0,
+            robot_target=pathlib.Path("~/suite/calculator.robot"),
+            variable_file=None,
+            argument_file=None,
+            retry_strategy=runner.RetryStrategy.INCREMENTAL,
         ),
         runner.Attempt(
-            output=pathlib.Path(
-                "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/1.xml"
+            output_directory=pathlib.Path(
+                "/tmp/outputdir/383783f41d0243b19d6f205f4d492d95"
             ),
-            command=[
-                "python",
-                "-m",
-                "robot",
-                "--variablefile=~/suite/retry.yaml",
-                "--rerunfailed=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/0.xml",
-                "--outputdir=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95",
-                "--output=/tmp/outputdir/383783f41d0243b19d6f205f4d492d95/1.xml",
-                "~/suite/calculator.robot",
-            ],
+            id_=uuid.UUID("383783f4-1d02-43b1-9d6f-205f4d492d95"),
+            index=1,
+            robot_target=pathlib.Path("~/suite/calculator.robot"),
+            variable_file=pathlib.Path("~/suite/retry.yaml"),
+            argument_file=None,
+            retry_strategy=runner.RetryStrategy.INCREMENTAL,
         ),
     ]


### PR DESCRIPTION
Implementing running in a different session via tasks will require access to the output directory, the id and the index of an attempt. Once `runner.Attempt` has these fields, we might as well move the logic to build a robot command there.

CMK-14088