### PR TITLE
Scheduler runner: Rename `Command` -> `SchedulerExecutionCommand`

### DIFF
--- a/checkmk_extensions/agent/scheduler_runner.ps1
+++ b/checkmk_extensions/agent/scheduler_runner.ps1
@@ -28,17 +28,17 @@ class Config {
     }
 }
 
-class Command {
+class SchedulerExecutionCommand {
     [string]$Executable
     [System.Collections.Generic.List[string]]$ArgumentsList
 
-    Command([string]$executable, [System.Collections.Generic.List[string]]$argumentsList) {
+    SchedulerExecutionCommand([string]$executable, [System.Collections.Generic.List[string]]$argumentsList) {
         $this.Executable = $executable
         $this.ArgumentsList = $argumentsList
     }
 
     # Method to create the command depending on the rcc value
-    static [Command] CreateCommand([Config]$config) {
+    static [SchedulerExecutionCommand] FromConfig([Config]$config) {
         $parentDir = Split-Path $PSScriptRoot -Parent
 
         if ($config.rcc) {
@@ -53,7 +53,7 @@ class Command {
             $_argumentsList = @("-m", $moduleName, "--config", $configPath)
         }
 
-        return [Command]::new($_executable, $_argumentsList)
+        return [SchedulerExecutionCommand]::new($_executable, $_argumentsList)
     }
 }
 
@@ -66,7 +66,7 @@ function StartSchedulerRunner {
 
     $config = [Config]::ParseConfigFile($configFilePath)
 
-    $command = [Command]::CreateCommand($config)
+    $command = [SchedulerExecutionCommand]::FromConfig($config)
     $parentDir = Split-Path $PSScriptRoot -Parent
     $logPath = Join-Path $parentDir "log\robotmk\scheduler_runner.log"
 


### PR DESCRIPTION
The name "Command" causes problems because of PSAvoidUsingCmdletAliases: 'Command' is implicitly aliasing 'Get-Command' because it is missing the 'Get-' prefix. This can introduce possible problems and make scripts hard to maintain. Please consider changing command to its full name.

CMK-14327