### PR TITLE
Scheduler: Switch to joint config format

### DIFF
--- a/checkmk_extensions/agent/scheduler_runner.ps1
+++ b/checkmk_extensions/agent/scheduler_runner.ps1
@@ -12,7 +12,7 @@ class RCCConfig {
 
     static [RCCConfig] ParseRawConfig([object]$RawConfig) {
         return [RCCConfig]::new(
-            $RawConfig.binary_path -as [string],
+            $RawConfig.rcc_binary_path -as [string],
             $RawConfig.scheduler_robot_yaml_path -as [string]
         )
     }
@@ -49,14 +49,14 @@ class Config {
         $resultsDir = $configData.results_directory -as [string]
         $logDir = $configData.log_directory -as [string]
 
-        if($null -eq $configData.rcc) {
+        if($configData.environment -eq "system_python") {
             return [Config]::new(
                 $resultsDir,
                 $logDir
                 )
         }
         return [Config]::new(
-            [RCCConfig]::ParseRawConfig($configData.rcc),
+            [RCCConfig]::ParseRawConfig($configData.environment),
             $resultsDir,
             $logDir
         )

--- a/v2/data/retry_rcc/windows.json
+++ b/v2/data/retry_rcc/windows.json
@@ -1,9 +1,13 @@
 {
+	"working_directory": "/tmp/outputdir",
+	"environment": {
+		"rcc_binary_path": "C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps\\rcc.exe",
+		"scheduler_robot_yaml_path": "C:\\robotmk\\v2\\data\\scheduler_rcc\\robot.yaml"
+	},
 	"suites": {
 		"test": {
 			"execution_interval_seconds": 10,
 			"robot_target": "C:\\robotmk\\v2\\data\\retry_suite\\/tasks.robot",
-			"working_directory": "/tmp/outputdir",
 			"variants": [
 				{
 					"variablefile": null,
@@ -15,10 +19,8 @@
 				}
 			],
 			"retry_strategy": "incremental",
-			"env": {
-				"binary": "C:\\Users\\vagrant\\AppData\\Local\\Microsoft\\WindowsApps\\rcc.exe",
-				"robot_yaml": "C:\\robotmk\\v2\\data\\retry_rcc\\/robot.yaml"
-			}
+			"robot_yaml_path": "C:\\robotmk\\v2\\data\\retry_rcc\\/robot.yaml",
+			"session": null
 		}
 	}
 }

--- a/v2/data/retry_rcc/windows.ps1
+++ b/v2/data/retry_rcc/windows.ps1
@@ -1,1 +1,1 @@
-poetry run python "C:\\robotmk\\v2\\robotmk\\scheduler.py" "C:\\robotmk\\v2\\data\\retry_rcc\\windows.json"
+python -m robotmk.scheduler "C:\\robotmk\\v2\\data\\retry_rcc\\windows.json"

--- a/v2/data/retry_suite/windows.json
+++ b/v2/data/retry_suite/windows.json
@@ -1,9 +1,10 @@
 {
+	"working_directory": "/tmp/outputdir",
+	"environment": "system_python",
 	"suites": {
 		"test": {
 			"execution_interval_seconds": 10,
 			"robot_target": "C:\\robotmk\\v2\\data\\retry_suite\\/tasks.robot",
-			"working_directory": "/tmp/outputdir",
 			"variants": [
 				{
 					"variablefile": null,
@@ -15,7 +16,7 @@
 				}
 			],
 			"retry_strategy": "incremental",
-			"env": null
+			"session": null
 		}
 	}
 }

--- a/v2/data/retry_suite/windows.ps1
+++ b/v2/data/retry_suite/windows.ps1
@@ -1,1 +1,1 @@
-poetry run python "C:\\robotmk\\v2\\robotmk\\scheduler.py" "C:\\robotmk\\v2\\data\\retry_suite\\windows.json"
+python -m robotmk.scheduler "C:\\robotmk\\v2\\data\\retry_suite\\windows.json"

--- a/v2/data/scheduler_rcc/conda.yaml
+++ b/v2/data/scheduler_rcc/conda.yaml
@@ -1,0 +1,8 @@
+channels:   
+  - conda-forge
+
+dependencies:   
+  - python=3.11.4
+  - pip
+  - pip:       
+      - "C:\\robotmk"

--- a/v2/data/scheduler_rcc/robot.yaml
+++ b/v2/data/scheduler_rcc/robot.yaml
@@ -1,0 +1,7 @@
+tasks: 
+  execute: 
+    command:       
+      - irrelevant
+
+condaConfigFile: conda.yaml
+artifactsDir: /tmp


### PR DESCRIPTION
The configuration will be shared with the scheduler runner and the agent plugin which produces the final section.

* RCC usage is configurable globally, not on a per-suite bases.
* Working directory is configurable globally, not on a per-suite bases.

CMK-14346