### PR TITLE
RCC building: Use actions/checkout@v4

### DIFF
--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 


### PR DESCRIPTION
This might avoid the error described in
https://github.com/orgs/community/discussions/26321

However, we haven't encountered these errors in the RCC build up to now.