### PR TITLE
refactor: simplify logging function and reduce the use of it

### DIFF
--- a/v2/rust/src/logging.rs
+++ b/v2/rust/src/logging.rs
@@ -19,13 +19,6 @@ pub fn init(
 }
 
 pub fn log_and_return_error(error: Error) -> Error {
-    error!(
-        "{}",
-        error
-            .chain()
-            .map(|e| e.to_string())
-            .collect::<Vec<String>>()
-            .join("\n")
-    );
+    error!("{error:?}");
     error
 }

--- a/v2/rust/src/main.rs
+++ b/v2/rust/src/main.rs
@@ -18,23 +18,23 @@ use std::thread::sleep;
 use std::time::Duration;
 
 fn main() -> Result<()> {
+    run().map_err(log_and_return_error)?;
+    Ok(())
+}
+
+fn run() -> Result<()> {
     let args = cli::Args::parse();
     logging::init(args.log_specification(), &args.log_path)?;
     info!("Program started and logging set up");
 
-    let conf = config::load(&args.config_path)
-        .context("Configuration loading failed")
-        .map_err(log_and_return_error)?;
+    let conf = config::load(&args.config_path).context("Configuration loading failed")?;
     debug!("Configuration loaded");
 
-    setup::setup(&conf)
-        .context("Setup failed")
-        .map_err(log_and_return_error)?;
+    setup::setup(&conf).context("Setup failed")?;
     debug!("Setup completed");
 
-    let termination_flag = termination::start_termination_control()
-        .context("Failed to set up termination control")
-        .map_err(log_and_return_error)?;
+    let termination_flag =
+        termination::start_termination_control().context("Failed to set up termination control")?;
     debug!("Termination control set up");
 
     loop {


### PR DESCRIPTION
Just a small suggestion regarding the logging to remove some redundancy in the main function.

Also I adjusted the logging function to use debug printing. Even though it doesn't have the same result as the previous code, it comes relatively close to it. Feel free to tell me if I should remove it. Here's a small example to check how the log's looks will change with that

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b55ea9f2371fce321ab0ae2fc954ce54