### PR TITLE
Force paths to be valid UTF-8

### DIFF
--- a/v2/rust/Cargo.lock
+++ b/v2/rust/Cargo.lock
@@ -277,6 +277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +947,7 @@ dependencies = [
  "async-std",
  "atomicwrites",
  "base64",
+ "camino",
  "chrono",
  "clap",
  "clokwerk",

--- a/v2/rust/Cargo.toml
+++ b/v2/rust/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { version = "*", features = ["backtrace"] }
 async-std = "*"
 atomicwrites = "*"
 base64 = "*"
+camino = { version = "1.1.6", features = ["serde1"] }
 chrono = "0.4.31"
 clap = { version = "*", features = ["derive"] }
 clokwerk = "*"

--- a/v2/rust/src/attempt.rs
+++ b/v2/rust/src/attempt.rs
@@ -1,5 +1,5 @@
 use super::config::{RetryStrategy, RobotFrameworkConfig};
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 use std::process::Command;
 
 pub const PYTHON_EXECUTABLE: &str = "python";
@@ -12,14 +12,14 @@ pub struct Identifier<'a> {
 
 pub struct RetrySpec<'a> {
     pub identifier: Identifier<'a>,
-    pub working_directory: &'a PathBuf,
+    pub working_directory: &'a Utf8PathBuf,
     pub n_retries_max: usize,
     pub timeout: u64,
     pub robot_framework_config: &'a RobotFrameworkConfig,
 }
 
 impl RetrySpec<'_> {
-    pub fn output_directory(&self) -> PathBuf {
+    pub fn output_directory(&self) -> Utf8PathBuf {
         self.working_directory
             .join(self.identifier.name)
             .join(&self.identifier.timestamp)
@@ -38,7 +38,7 @@ impl RetrySpec<'_> {
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct Attempt<'a> {
-    pub output_directory: PathBuf,
+    pub output_directory: Utf8PathBuf,
     pub identifier: &'a Identifier<'a>,
     pub index: usize,
     pub timeout: u64,
@@ -46,7 +46,7 @@ pub struct Attempt<'a> {
 }
 
 impl Attempt<'_> {
-    pub fn output_xml_file(&self) -> PathBuf {
+    pub fn output_xml_file(&self) -> Utf8PathBuf {
         self.output_directory.join(format!("{}.xml", self.index))
     }
 
@@ -92,9 +92,9 @@ mod tests {
             .arg("--outputdir")
             .arg("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00")
             .arg("--output")
-            .arg(PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.xml"))
+            .arg(Utf8PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.xml"))
             .arg("--log")
-            .arg(PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.html"))
+            .arg(Utf8PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.html"))
             .arg("--report")
             .arg("NONE")
             .arg("~/suite/calculator.robot");
@@ -174,13 +174,13 @@ mod tests {
             .arg("-m")
             .arg("robot")
             .arg("--rerunfailed")
-            .arg(PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.xml"))
+            .arg(Utf8PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("0.xml"))
             .arg("--outputdir")
             .arg("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00")
             .arg("--output")
-            .arg(PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("1.xml"))
+            .arg(Utf8PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("1.xml"))
             .arg("--log")
-            .arg(PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("1.html"))
+            .arg(Utf8PathBuf::from("/tmp/my_suite/2023-08-29T12.23.44.419347+00.00").join("1.html"))
             .arg("--report")
             .arg("NONE")
             .arg("~/suite/calculator.robot");
@@ -198,7 +198,7 @@ mod tests {
                 name: "suite_1",
                 timestamp: "2023-08-29T12.23.44.419347+00.00".into(),
             },
-            working_directory: &PathBuf::from("/tmp/outputdir/"),
+            working_directory: &Utf8PathBuf::from("/tmp/outputdir/"),
             n_retries_max: 2,
             timeout: 300,
             robot_framework_config: &RobotFrameworkConfig {

--- a/v2/rust/src/cli.rs
+++ b/v2/rust/src/cli.rs
@@ -1,17 +1,17 @@
+use camino::Utf8PathBuf;
 use clap::{ArgAction, Parser};
 use flexi_logger::LogSpecification;
-use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(about = "Robotmk suite scheduler.")]
 pub struct Args {
     /// Configuration file path.
     #[arg(name = "CONFIG_PATH")]
-    pub config_path: PathBuf,
+    pub config_path: Utf8PathBuf,
 
     /// Log file path. If left unspecified, the program will log to standard error.
     #[arg(long, name = "LOG_PATH")]
-    pub log_path: Option<PathBuf>,
+    pub log_path: Option<Utf8PathBuf>,
 
     /// Enable verbose output. Use once (-v) for logging level INFO and twice (-vv) for logging
     /// level DEBUG.

--- a/v2/rust/src/config.rs
+++ b/v2/rust/src/config.rs
@@ -1,17 +1,18 @@
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use serde_json::from_str;
 use std::collections::HashMap;
 use std::fs::read_to_string;
-use std::path::{Path, PathBuf};
 
-pub fn load(path: &Path) -> anyhow::Result<Config> {
+pub fn load(path: &Utf8Path) -> Result<Config> {
     Ok(from_str(&read_to_string(path)?)?)
 }
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub working_directory: PathBuf,
-    pub results_directory: PathBuf,
+    pub working_directory: Utf8PathBuf,
+    pub results_directory: Utf8PathBuf,
     suites: HashMap<String, SuiteConfig>,
 }
 
@@ -27,9 +28,9 @@ pub struct SuiteConfig {
 #[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct RobotFrameworkConfig {
-    pub robot_target: PathBuf,
-    pub variable_file: Option<PathBuf>,
-    pub argument_file: Option<PathBuf>,
+    pub robot_target: Utf8PathBuf,
+    pub variable_file: Option<Utf8PathBuf>,
+    pub argument_file: Option<Utf8PathBuf>,
     pub retry_strategy: RetryStrategy,
 }
 
@@ -59,9 +60,9 @@ pub enum EnvironmentConfig {
 #[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct RCCEnvironmentConfig {
-    pub binary_path: PathBuf,
-    pub robocorp_home_path: PathBuf,
-    pub robot_yaml_path: PathBuf,
+    pub binary_path: Utf8PathBuf,
+    pub robocorp_home_path: Utf8PathBuf,
+    pub robot_yaml_path: Utf8PathBuf,
     pub build_timeout: u64,
 }
 
@@ -97,7 +98,7 @@ mod tests {
     fn create_suite_config(suite_name: &str) -> SuiteConfig {
         SuiteConfig {
             robot_framework_config: RobotFrameworkConfig {
-                robot_target: PathBuf::from(format!("/suite/{}/tasks.robot", suite_name)),
+                robot_target: Utf8PathBuf::from(format!("/suite/{}/tasks.robot", suite_name)),
                 variable_file: None,
                 argument_file: None,
                 retry_strategy: RetryStrategy::Complete,
@@ -114,8 +115,8 @@ mod tests {
 
     fn create_config() -> Config {
         Config {
-            working_directory: PathBuf::from("/working"),
-            results_directory: PathBuf::from("/results"),
+            working_directory: Utf8PathBuf::from("/working"),
+            results_directory: Utf8PathBuf::from("/results"),
             suites: HashMap::from([
                 (String::from("suite_b"), create_suite_config("b")),
                 (String::from("suite_a"), create_suite_config("a")),

--- a/v2/rust/src/environment.rs
+++ b/v2/rust/src/environment.rs
@@ -3,11 +3,11 @@ use super::config::{Config, EnvironmentConfig};
 use super::results::{EnvironmentBuildStatesAdministrator, EnvironmentBuildStatus};
 use super::termination::TerminationFlag;
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 use log::{debug, error, info};
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub fn environment_building_stdio_directory(working_directory: &Path) -> PathBuf {
+pub fn environment_building_stdio_directory(working_directory: &Utf8Path) -> Utf8PathBuf {
     working_directory.join("environment_building_stdio")
 }
 
@@ -58,21 +58,21 @@ pub fn build_environments(config: &Config, termination_flag: &TerminationFlag) -
 }
 
 fn configure_stdio_of_environment_build(
-    stdio_directory: &Path,
+    stdio_directory: &Utf8Path,
     suite_name: &str,
     build_command: &mut Command,
 ) -> Result<()> {
     let path_stdout = stdio_directory.join(format!("{}.stdout", suite_name));
     let path_stderr = stdio_directory.join(format!("{}.stderr", suite_name));
     build_command
-        .stdout(std::fs::File::create(&path_stdout).context(format!(
-            "Failed to open {} for stdout capturing",
-            &path_stdout.display()
-        ))?)
-        .stderr(std::fs::File::create(&path_stderr).context(format!(
-            "Failed to open {} for stderr capturing",
-            &path_stderr.display()
-        ))?);
+        .stdout(
+            std::fs::File::create(&path_stdout)
+                .context(format!("Failed to open {path_stdout} for stdout capturing",))?,
+        )
+        .stderr(
+            std::fs::File::create(&path_stderr)
+                .context(format!("Failed to open {path_stderr} for stderr capturing",))?,
+        );
     Ok(())
 }
 
@@ -107,9 +107,9 @@ pub enum Environment {
 pub struct SystemEnvironment {}
 
 pub struct RCCEnvironment {
-    binary_path: PathBuf,
-    robocorp_home_path: PathBuf,
-    robot_yaml_path: PathBuf,
+    binary_path: Utf8PathBuf,
+    robocorp_home_path: Utf8PathBuf,
+    robot_yaml_path: Utf8PathBuf,
     controller: String,
     space: String,
     build_timeout: u64,
@@ -241,9 +241,9 @@ mod tests {
         assert!(Environment::new(
             "my_suite",
             &EnvironmentConfig::Rcc(RCCEnvironmentConfig {
-                binary_path: PathBuf::from("/bin/rcc"),
-                robocorp_home_path: PathBuf::from("/robocorp_home"),
-                robot_yaml_path: PathBuf::from("/a/b/c/robot.yaml"),
+                binary_path: Utf8PathBuf::from("/bin/rcc"),
+                robocorp_home_path: Utf8PathBuf::from("/robocorp_home"),
+                robot_yaml_path: Utf8PathBuf::from("/a/b/c/robot.yaml"),
                 build_timeout: 60,
             })
         )
@@ -294,9 +294,9 @@ mod tests {
             format!(
                 "{:?}",
                 RCCEnvironment {
-                    binary_path: PathBuf::from("C:\\bin\\z.exe"),
-                    robocorp_home_path: PathBuf::from("C:\\robocorp_home"),
-                    robot_yaml_path: PathBuf::from("C:\\my_suite\\robot.yaml"),
+                    binary_path: Utf8PathBuf::from("C:\\bin\\z.exe"),
+                    robocorp_home_path: Utf8PathBuf::from("C:\\robocorp_home"),
+                    robot_yaml_path: Utf8PathBuf::from("C:\\my_suite\\robot.yaml"),
                     controller: String::from("robotmk"),
                     space: String::from("my_suite"),
                     build_timeout: 600,
@@ -326,9 +326,9 @@ mod tests {
             format!(
                 "{:?}",
                 RCCEnvironment {
-                    binary_path: PathBuf::from("/bin/rcc"),
-                    robocorp_home_path: PathBuf::from("/robocorp_home"),
-                    robot_yaml_path: PathBuf::from("/a/b/c/robot.yaml"),
+                    binary_path: Utf8PathBuf::from("/bin/rcc"),
+                    robocorp_home_path: Utf8PathBuf::from("/robocorp_home"),
+                    robot_yaml_path: Utf8PathBuf::from("/a/b/c/robot.yaml"),
                     controller: String::from("robotmk"),
                     space: String::from("my_suite"),
                     build_timeout: 123,

--- a/v2/rust/src/logging.rs
+++ b/v2/rust/src/logging.rs
@@ -1,13 +1,13 @@
 use anyhow::Error;
+use camino::Utf8PathBuf;
 use flexi_logger::{
     detailed_format, FileSpec, FlexiLoggerError, LogSpecification, Logger, LoggerHandle,
 };
 use log::error;
-use std::path::PathBuf;
 
 pub fn init(
     specification: LogSpecification,
-    path: &Option<PathBuf>,
+    path: &Option<Utf8PathBuf>,
 ) -> Result<LoggerHandle, FlexiLoggerError> {
     let logger = Logger::with(specification);
     match path {

--- a/v2/rust/src/rebot.rs
+++ b/v2/rust/src/rebot.rs
@@ -3,17 +3,17 @@ use super::environment::Environment;
 use super::results::{RebotOutcome, RebotResult};
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose, Engine};
+use camino::{Utf8Path, Utf8PathBuf};
 use log::debug;
 use log::error;
 use std::fs::{read, read_to_string};
-use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 pub struct Rebot<'a> {
     pub environment: &'a Environment,
-    pub input_paths: &'a [PathBuf],
-    pub path_xml: &'a Path,
-    pub path_html: &'a Path,
+    pub input_paths: &'a [Utf8PathBuf],
+    pub path_xml: &'a Utf8Path,
+    pub path_html: &'a Utf8Path,
 }
 
 impl Rebot<'_> {
@@ -69,7 +69,7 @@ impl Rebot<'_> {
                 Err(error) => {
                     let error_message = format!(
                         "Failed to read merged HTML file content from {}: {error:?}",
-                        self.path_html.display()
+                        self.path_html
                     );
                     error!("{error_message}");
                     RebotOutcome::Error(error_message)
@@ -78,7 +78,7 @@ impl Rebot<'_> {
             Err(error) => {
                 let error_message = format!(
                     "Failed to read merged XML file content from {}: {error:?}",
-                    self.path_xml.display()
+                    self.path_xml
                 );
                 error!("{error_message}");
                 RebotOutcome::Error(error_message)
@@ -97,11 +97,11 @@ mod tests {
         let rebot_command = Rebot {
             environment: &Environment::new("my_suite", &EnvironmentConfig::System),
             input_paths: &[
-                PathBuf::from("/working/my_suite/0.xml"),
-                PathBuf::from("/working/my_suite/1.xml"),
+                Utf8PathBuf::from("/working/my_suite/0.xml"),
+                Utf8PathBuf::from("/working/my_suite/1.xml"),
             ],
-            path_xml: &PathBuf::from("/working/my_suite/rebot.xml"),
-            path_html: &PathBuf::from("/working/my_suite/rebot.html"),
+            path_xml: &Utf8PathBuf::from("/working/my_suite/rebot.xml"),
+            path_html: &Utf8PathBuf::from("/working/my_suite/rebot.html"),
         }
         .build_rebot_command();
         let mut expected = Command::new("python");

--- a/v2/rust/src/results.rs
+++ b/v2/rust/src/results.rs
@@ -1,19 +1,23 @@
 use anyhow::{Context, Result};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::Serialize;
 use serde_json::to_string;
-use std::path::{Path, PathBuf};
 use std::{collections::HashMap, io::Write};
 
-pub fn suite_results_directory(results_directory: &Path) -> PathBuf {
+pub fn suite_results_directory(results_directory: &Utf8Path) -> Utf8PathBuf {
     results_directory.join("suites")
 }
 
-pub fn suite_result_file(suite_results_dir: &Path, suite_name: &str) -> PathBuf {
+pub fn suite_result_file(suite_results_dir: &Utf8Path, suite_name: &str) -> Utf8PathBuf {
     suite_results_dir.join(format!("{}.json", suite_name))
 }
 
-pub fn write_file_atomic(content: &str, working_directory: &Path, final_path: &Path) -> Result<()> {
+pub fn write_file_atomic(
+    content: &str,
+    working_directory: &Utf8Path,
+    final_path: &Utf8PathBuf,
+) -> Result<()> {
     AtomicFile::new_with_tmpdir(
         final_path,
         OverwriteBehavior::AllowOverwrite,
@@ -21,23 +25,21 @@ pub fn write_file_atomic(content: &str, working_directory: &Path, final_path: &P
     )
     .write(|f| f.write_all(content.as_bytes()))
     .context(format!(
-        "Atomic write failed. Working directory: {}, final path: {}.",
-        working_directory.display(),
-        final_path.display()
+        "Atomic write failed. Working directory: {working_directory}, final path: {final_path}.",
     ))
 }
 
 pub struct EnvironmentBuildStatesAdministrator<'a> {
     build_states: HashMap<&'a String, EnvironmentBuildStatus>,
-    working_directory: &'a Path,
-    results_directory: &'a Path,
+    working_directory: &'a Utf8Path,
+    results_directory: &'a Utf8Path,
 }
 
 impl<'a> EnvironmentBuildStatesAdministrator<'a> {
     pub fn new_with_pending(
         suite_names: impl Iterator<Item = &'a String>,
-        working_directory: &'a Path,
-        results_directory: &'a Path,
+        working_directory: &'a Utf8Path,
+        results_directory: &'a Utf8Path,
     ) -> EnvironmentBuildStatesAdministrator<'a> {
         Self {
             build_states: HashMap::from_iter(

--- a/v2/rust/src/session.rs
+++ b/v2/rust/src/session.rs
@@ -4,7 +4,7 @@ use super::config::SessionConfig;
 use super::environment::{Environment, ResultCode};
 use super::termination::TerminationFlag;
 use anyhow::{Context, Ok, Result};
-use std::path::PathBuf;
+use camino::Utf8PathBuf;
 use std::process::Command;
 
 pub enum Session<'a> {
@@ -68,11 +68,11 @@ impl CurrentSession<'_> {
         command
             .stdout(std::fs::File::create(&stdio_paths.stdout).context(format!(
                 "Failed to open {} for stdout capturing",
-                &stdio_paths.stdout.display()
+                stdio_paths.stdout
             ))?)
             .stderr(std::fs::File::create(&stdio_paths.stderr).context(format!(
                 "Failed to open {} for stderr capturing",
-                &stdio_paths.stderr.display()
+                stdio_paths.stderr
             ))?);
         Ok(command)
     }
@@ -90,6 +90,6 @@ fn stdio_paths_for_attempt(attempt: &Attempt) -> StdioPaths {
 }
 
 struct StdioPaths {
-    stdout: PathBuf,
-    stderr: PathBuf,
+    stdout: Utf8PathBuf,
+    stderr: Utf8PathBuf,
 }

--- a/v2/rust/src/setup.rs
+++ b/v2/rust/src/setup.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use atomicwrites::replace_atomic;
+use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::HashSet;
-use std::fs::{create_dir_all, read_dir, remove_file};
-use std::path::{Path, PathBuf};
+use std::fs::{create_dir_all, remove_file};
 
 use super::config::Config;
 use super::environment::environment_building_stdio_directory;
@@ -29,31 +29,29 @@ fn clean_up_results_directory_atomic(config: &Config) -> Result<()> {
     let currently_present_result_files = currently_present_result_files(&suite_results_directory)?;
     remove_files_atomic(
         &suite_results_directory.join("deprecated_result"),
-        HashSet::<PathBuf>::from_iter(currently_present_result_files)
+        HashSet::<Utf8PathBuf>::from_iter(currently_present_result_files)
             .difference(&HashSet::from_iter(result_files_to_keep)),
     )
 }
 
-fn currently_present_result_files(suite_results_directory: &Path) -> Result<Vec<PathBuf>> {
+fn currently_present_result_files(suite_results_directory: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
     let mut result_files = vec![];
 
-    for dir_entry in read_dir(suite_results_directory).context(format!(
-        "Failed to read entries of results directory {}",
-        suite_results_directory.display()
+    for dir_entry in suite_results_directory.read_dir_utf8().context(format!(
+        "Failed to read entries of results directory {suite_results_directory}",
     ))? {
         let dir_entry = dir_entry.context(format!(
-            "Failed to read entries of results directory {}",
-            suite_results_directory.display()
+            "Failed to read entries of results directory {suite_results_directory}",
         ))?;
         if dir_entry
             .file_type()
             .context(format!(
                 "Failed to determine file type of {}",
-                dir_entry.path().display()
+                dir_entry.path()
             ))?
             .is_file()
         {
-            result_files.push(dir_entry.path())
+            result_files.push(dir_entry.path().to_path_buf())
         }
     }
 
@@ -61,15 +59,13 @@ fn currently_present_result_files(suite_results_directory: &Path) -> Result<Vec<
 }
 
 fn remove_files_atomic<'a>(
-    intermediate_path_for_move: &Path,
-    files_to_be_removed: impl Iterator<Item = &'a PathBuf>,
+    intermediate_path_for_move: &Utf8Path,
+    files_to_be_removed: impl Iterator<Item = &'a Utf8PathBuf>,
 ) -> Result<()> {
     for path in files_to_be_removed {
-        replace_atomic(path, intermediate_path_for_move).context(format!(
-            "Failed to move {} to {}",
-            path.display(),
-            intermediate_path_for_move.display()
-        ))?;
+        replace_atomic(path.as_std_path(), intermediate_path_for_move.as_std_path()).context(
+            format!("Failed to move {path} to {intermediate_path_for_move}",),
+        )?;
     }
 
     let _ = remove_file(intermediate_path_for_move);


### PR DESCRIPTION
This will make it easier to implement headful tests, where we have to write these paths to files.