### PR TITLE
vagrant: add scheduler components via shell script

### DIFF
--- a/vagrant/f12.sh
+++ b/vagrant/f12.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Todo: Only update out-of-date things.
+
+topdir="$(git rev-parse --show-toplevel)"
+rustdir="$topdir"/v2/rust/
+
+agentdir="C:/ProgramData/checkmk/agent"
+agentplugindir="$agentdir"/plugins
+agentconfigdir="$agentdir"/config
+agentbindir="$agentdir"/bin
+
+# Sync robotmk.exe to vagrant machine
+(cd "$rustdir"; cargo build --target=x86_64-pc-windows-gnu)
+sshpass -p "vagrant" scp -P 2222 "$rustdir"/target/x86_64-pc-windows-gnu/debug/robotmk.exe vagrant@127.0.0.1:"$agentbindir"
+
+# Sync collector.ps1 to vagrant machine
+sshpass -p "vagrant" scp -P 2222 "$topdir"/checkmk_extensions/agent/robotmk_collector.ps1 vagrant@127.0.0.1:"$agentplugindir"
+
+# Sync config for collector.ps1 to vagrant machine
+sshpass -p "vagrant" scp -P 2222 "$topdir"/v2/data/retry_rcc/windows.json vagrant@127.0.0.1:"$agentconfigdir"/robotmk.json

--- a/vagrant/setup.md
+++ b/vagrant/setup.md
@@ -1,0 +1,27 @@
+# Dependencies for creating Virtual machine as a Linux host
+
+- VirtualBox
+- Vagrant
+
+For provisioning the machine only:
+
+- Ansible
+- Checkmk Ansible collection found here https://galaxy.ansible.com/checkmk/general
+  ```
+  ansible-galaxy collection install checkmk.general
+  ```
+
+For running f12.sh only:
+
+- Mingw-w64 of cross-compilation
+  ```
+  sudo apt install mingw-w64
+  ```
+- Rust cross-compilation target `x86_64-pc-windows-gnu`
+  ```
+  rustup target add x86_64-pc-windows-gnu
+  ```
+- sshpass
+  ```
+  sudo apt install sshpass
+  ```


### PR DESCRIPTION
The script deploys artefacts, which reflects the current git state (with the exception of the go binary, which rebuilt daily instead).

In the future, we also need a mechanism to deploy via the agent bakery.

CMK-14648