### PR TITLE
Draft: simplify logging

### DIFF
--- a/v2/robotmk/src/logging.rs
+++ b/v2/robotmk/src/logging.rs
@@ -19,13 +19,6 @@ pub fn init(
 }
 
 pub fn log_and_return_error(error: Error) -> Error {
-    error!(
-        "{}",
-        error
-            .chain()
-            .map(|e| e.to_string())
-            .collect::<Vec<String>>()
-            .join("\n")
-    );
+    error!("{error:?}");
     error
 }

--- a/v2/robotmk/src/main.rs
+++ b/v2/robotmk/src/main.rs
@@ -20,27 +20,27 @@ use log::{debug, info};
 use logging::log_and_return_error;
 
 fn main() -> Result<()> {
+    run().map_err(log_and_return_error)?;
+    Ok(())
+}
+
+fn run() -> Result<()> {
     let args = cli::Args::parse();
     logging::init(args.log_specification(), &args.log_path)?;
     info!("Program started and logging set up");
 
-    let conf = config::load(&args.config_path)
-        .context("Configuration loading failed")
-        .map_err(log_and_return_error)?;
+    let conf = config::load(&args.config_path).context("Configuration loading failed")?;
     debug!("Configuration loaded");
 
-    setup::setup(&conf)
-        .context("Setup failed")
-        .map_err(log_and_return_error)?;
+    setup::setup(&conf).context("Setup failed")?;
     debug!("Setup completed");
 
-    let termination_flag = termination::start_termination_control()
-        .context("Failed to set up termination control")
-        .map_err(log_and_return_error)?;
+    let termination_flag =
+        termination::start_termination_control().context("Failed to set up termination control")?;
     debug!("Termination control set up");
 
     info!("Starting environment building");
-    environment::build_environments(&conf, &termination_flag).map_err(log_and_return_error)?;
+    environment::build_environments(&conf, &termination_flag)?;
     info!("Environment building finished");
 
     info!("Starting suite scheduling");


### PR DESCRIPTION
This PR is just a small suggestion to reduce all code that is concerned with logging a bit.

Reopened version of #348 

## Commit summaries

---

### refactor: simplify logging function and reduce the use of it

- build a layer between the main function and the early returns via `?` to remove duplication of the usage of `log_and_return_error`
- simplify `log_and_return_error` by using debug printing instead of formatting all the context layers manually

the difference in error formatting is the following:

The code 

```rust
fn main() -> anyhow::Result<()> {
    let err = anyhow::anyhow!("Error: Something unexpected happend!")
        .context("Have you checked the fuse?")
        .context("Ooops, something exploded! 💣");
    println!("=== old ===");
    let old = err
        .chain()
        .map(|e| e.to_string())
        .collect::<Vec<_>>()
        .join("\n");
    println!("{old}");
    println!("=== new ===");
    println!("{err:?}");
    Ok(())
}
```

produces the following output

```
=== old ===
Ooops, something exploded! 💣
Have you checked the fuse?
Error: Something unexpected happend!
=== new ===
Ooops, something exploded! 💣

Caused by:
    0: Have you checked the fuse?
    1: Error: Something unexpected happend!
```

---

### chore: update to respect changes that happened in the mean time

update the PR to respect changes that happened between it's initial version and now

---