### PR TITLE
Add possibility to provide path as argument and default value 

### DIFF
--- a/checkmk_extensions/agent/robotmk_collector.ps1
+++ b/checkmk_extensions/agent/robotmk_collector.ps1
@@ -2,10 +2,7 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop"
 
 function Main {
-    Param (
-        [parameter(Mandatory=$true, Position=0)]
-        [string]$ConfigPath
-    )
+    $ConfigPath = DetermineConfigPath -CommandLineArgs $args
     Write-Output "<<<robotmk_v2:sep(10)>>>"
 
     try {
@@ -27,6 +24,24 @@ function Main {
 }
 
 
+function DetermineConfigPath {
+    [OutputType([string])]
+    Param (
+        [parameter(Mandatory=$false, Position=0)]
+        [String[]]$CommandLineArgs
+    )
+
+    if ($CommandLineArgs -ne "" -and $CommandLineArgs.Count -gt 0) {
+        return $CommandLineArgs[0]
+    }
+
+    $configDir = $env:MK_CONFDIR
+    if ($null -eq $configDir) {
+        $configDir = 'C:\ProgramData\checkmk\agent\config'
+    }
+
+    return Join-Path $configDir 'robotmk.json'
+}
 function SerializeConfigReadingError {
     [OutputType([string])]
     Param (
@@ -56,4 +71,4 @@ function GetResultsDirectory {
     return $configData.results_directory -as [string]
 }
 
-Main("${env:MK_CONFDIR}\robotmk.json")
+Main $args


### PR DESCRIPTION
Added possibility to call the script with an argument:
`./robotmk_collector.ps1 "path_as_argument"`

Also, if `env:MK_CONFDIR` is not present, the path will default to `C:\ProgramData\checkmk\agent\config\robotmk.json`