### PR TITLE
Decouple `Session` and `Environment`

### DIFF
--- a/v2/robotmk/src/child_process_supervisor.rs
+++ b/v2/robotmk/src/child_process_supervisor.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use sysinfo::{Pid, PidExt, Process, ProcessExt, System, SystemExt};
 
 pub struct ChildProcessSupervisor<'a> {
-    pub command_spec: CommandSpec,
+    pub command_spec: &'a CommandSpec,
     pub stdio_paths: Option<StdioPaths>,
     pub timeout: u64,
     pub termination_flag: &'a TerminationFlag,
@@ -54,7 +54,7 @@ impl ChildProcessSupervisor<'_> {
     }
 
     fn build_command(&self) -> Result<Command> {
-        let mut command = Command::from(&self.command_spec);
+        let mut command = Command::from(self.command_spec);
         if let Some(stdio_paths) = &self.stdio_paths {
             command
                 .stdout(std::fs::File::create(&stdio_paths.stdout).context(format!(

--- a/v2/robotmk/src/environment.rs
+++ b/v2/robotmk/src/environment.rs
@@ -34,7 +34,7 @@ pub fn build_environments(config: &Config, termination_flag: &TerminationFlag) -
                 environment_build_states_administrator.insert_and_write_atomic(
                     suite_name,
                     run_environment_build(ChildProcessSupervisor {
-                        command_spec: build_instructions.command_spec,
+                        command_spec: &build_instructions.command_spec,
                         stdio_paths: Some(StdioPaths {
                             stdout: env_building_stdio_directory
                                 .join(format!("{suite_name}.stdout")),

--- a/v2/robotmk/src/session.rs
+++ b/v2/robotmk/src/session.rs
@@ -1,67 +1,60 @@
-use super::attempt::Attempt;
 use super::child_process_supervisor::{ChildProcessOutcome, ChildProcessSupervisor, StdioPaths};
+use super::command_spec::CommandSpec;
 use super::config::SessionConfig;
-use super::environment::{Environment, ResultCode};
 use super::termination::TerminationFlag;
-use anyhow::Result;
 
-pub enum Session<'a> {
-    Current(CurrentSession<'a>),
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+
+pub enum Session {
+    Current(CurrentSession),
 }
 
-impl Session<'_> {
-    pub fn new<'a>(
-        session_config: &SessionConfig,
-        environment: &'a Environment,
-        termination_flag: &'a TerminationFlag,
-    ) -> Session<'a> {
+impl Session {
+    pub fn new(session_config: &SessionConfig) -> Session {
         match session_config {
-            SessionConfig::Current => Session::<'a>::Current(CurrentSession {
-                environment,
-                termination_flag,
-            }),
+            SessionConfig::Current => Session::Current(CurrentSession {}),
             SessionConfig::SpecificUser(_) => panic!("User sessions not yet implemented!"),
         }
     }
 
-    pub fn run(&self, attempt: &Attempt) -> Result<RunOutcome> {
+    pub fn run(&self, spec: &RunSpec) -> Result<RunOutcome> {
         match self {
-            Self::Current(current_session) => current_session.run(attempt),
+            Self::Current(current_session) => current_session.run(spec),
         }
     }
 }
 
-pub struct CurrentSession<'a> {
-    environment: &'a Environment,
-    termination_flag: &'a TerminationFlag,
+pub struct CurrentSession {}
+
+pub struct RunSpec<'a> {
+    pub id: &'a str,
+    pub command_spec: &'a CommandSpec,
+    pub base_path: &'a Utf8Path,
+    pub timeout: u64,
+    pub termination_flag: &'a TerminationFlag,
 }
 
 pub enum RunOutcome {
-    Exited(Option<ResultCode>),
+    Exited(Option<i32>),
     TimedOut,
 }
 
-impl CurrentSession<'_> {
-    fn run(&self, attempt: &Attempt) -> Result<RunOutcome> {
+impl CurrentSession {
+    fn run(&self, spec: &RunSpec) -> Result<RunOutcome> {
         match (ChildProcessSupervisor {
-            command_spec: self.environment.wrap(attempt.command_spec()),
+            command_spec: spec.command_spec,
             stdio_paths: Some(StdioPaths {
-                stdout: attempt
-                    .output_directory
-                    .join(format!("{}.stdout", attempt.index)),
-                stderr: attempt
-                    .output_directory
-                    .join(format!("{}.stderr", attempt.index)),
+                stdout: Utf8PathBuf::from(format!("{}.stdout", spec.base_path)),
+                stderr: Utf8PathBuf::from(format!("{}.stderr", spec.base_path)),
             }),
-            timeout: attempt.timeout,
-            termination_flag: self.termination_flag,
+            timeout: spec.timeout,
+            termination_flag: spec.termination_flag,
         }
         .run())?
         {
             ChildProcessOutcome::Exited(exit_status) => match exit_status.code() {
-                Some(exit_code) => Ok(RunOutcome::Exited(Some(
-                    self.environment.create_result_code(exit_code),
-                ))),
+                Some(exit_code) => Ok(RunOutcome::Exited(Some(exit_code))),
                 None => Ok(RunOutcome::Exited(None)),
             },
             ChildProcessOutcome::TimedOut => Ok(RunOutcome::TimedOut),


### PR DESCRIPTION
This makes it easier to split the configuration into a global configuration and per-suite configuration.

Furthermore, originally, the idea was that `Session` takes a command as input, wraps it using `Environment` and then runs the wrapped command. However, the requirement that the scheduler configures shared holotrees means that `Session` must also be able to run un-wrappend commands (`rcc holotree init`). So decoupling these two also paves the way for implementing this requirement.

CMK-14802