### PR TITLE
Add generic option for RF command line arguments to configuration

### DIFF
--- a/v2/data/google-imagesearch/config.json
+++ b/v2/data/google-imagesearch/config.json
@@ -6,9 +6,8 @@
 		"googleimagesearch": {
 			"robot_framework_config": {
 				"robot_target": "C:\\rmk\\v2\\data\\google-imagesearch\\tasks.robot",
-				"variable_file": null,
-				"argument_file": null,
-				"retry_strategy": "Incremental"
+				"retry_strategy": "Incremental",
+				"command_line_args": []
 			},
 			"execution_config": {
 				"n_retries_max": 1,

--- a/v2/data/retry_rcc/windows.json
+++ b/v2/data/retry_rcc/windows.json
@@ -6,9 +6,8 @@
 		"test": {
 			"robot_framework_config": {
 				"robot_target": "C:\\robotmk\\v2\\data\\retry_suite\\tasks.robot",
-				"variable_file": "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml",
-				"argument_file": null,
-				"retry_strategy": "Incremental"
+				"retry_strategy": "Incremental",
+				"command_line_args": ["--variable_file", "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml"]
 			},
 			"execution_config": {
 				"n_retries_max": 1,

--- a/v2/data/retry_suite/windows.json
+++ b/v2/data/retry_suite/windows.json
@@ -5,9 +5,8 @@
 		"test": {
 			"robot_framework_config": {
 				"robot_target": "C:\\robotmk\\v2\\data\\retry_suite\\tasks.robot",
-				"variable_file": "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml",
-				"argument_file": null,
-				"retry_strategy": "Incremental"
+				"retry_strategy": "Incremental",
+				"command_line_args": ["--variable_file", "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml"]
 			},
 			"execution_config": {
 				"n_retries_max": 1,

--- a/v2/data/web-store-order-processor/config.json
+++ b/v2/data/web-store-order-processor/config.json
@@ -6,9 +6,8 @@
 		"webstore-playwright": {
 			"robot_framework_config": {
 				"robot_target": "C:\\rmk\\v2\\data\\web-store-order-processor\\tasks.robot",
-				"variable_file": null,
-				"argument_file": null,
-				"retry_strategy": "Incremental"
+				"retry_strategy": "Incremental",
+				"command_line_args": []
 			},
 			"execution_config": {
 				"n_retries_max": 1,

--- a/v2/robotmk/src/attempt.rs
+++ b/v2/robotmk/src/attempt.rs
@@ -51,16 +51,7 @@ impl Attempt<'_> {
     pub fn command_spec(&self) -> CommandSpec {
         let mut command_spec = CommandSpec::new(PYTHON_EXECUTABLE);
         command_spec.add_argument("-m").add_argument("robot");
-        if let Some(variable_file) = &self.robot_framework_config.variable_file {
-            command_spec
-                .add_argument("--variablefile")
-                .add_argument(variable_file);
-        }
-        if let Some(argument_file) = &self.robot_framework_config.argument_file {
-            command_spec
-                .add_argument("--argumentfile")
-                .add_argument(argument_file);
-        }
+        command_spec.add_arguments(&self.robot_framework_config.command_line_args);
         if matches!(
             self.robot_framework_config.retry_strategy,
             RetryStrategy::Incremental
@@ -123,8 +114,7 @@ mod tests {
             timeout: 200,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Complete,
             },
         };
@@ -148,8 +138,7 @@ mod tests {
             timeout: 200,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Incremental,
             },
         };
@@ -173,8 +162,7 @@ mod tests {
             timeout: 200,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Incremental,
             },
         };
@@ -218,8 +206,7 @@ mod tests {
             timeout: 300,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: Some("~/suite/retry.yaml".into()),
-                argument_file: None,
+                command_line_args: vec!["--variablefile".into(), "~/suite/retry.yaml".into()],
                 retry_strategy: RetryStrategy::Incremental,
             },
         };
@@ -233,8 +220,7 @@ mod tests {
             timeout: 300,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: Some("~/suite/retry.yaml".into()),
-                argument_file: None,
+                command_line_args: vec!["--variablefile".into(), "~/suite/retry.yaml".into()],
                 retry_strategy: RetryStrategy::Incremental,
             },
         };
@@ -248,8 +234,7 @@ mod tests {
             timeout: 300,
             robot_framework_config: &RobotFrameworkConfig {
                 robot_target: "~/suite/calculator.robot".into(),
-                variable_file: Some("~/suite/retry.yaml".into()),
-                argument_file: None,
+                command_line_args: vec!["--variablefile".into(), "~/suite/retry.yaml".into()],
                 retry_strategy: RetryStrategy::Incremental,
             },
         };

--- a/v2/robotmk/src/config/external.rs
+++ b/v2/robotmk/src/config/external.rs
@@ -29,9 +29,8 @@ pub struct SuiteConfig {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct RobotFrameworkConfig {
     pub robot_target: Utf8PathBuf,
-    pub variable_file: Option<Utf8PathBuf>,
-    pub argument_file: Option<Utf8PathBuf>,
     pub retry_strategy: RetryStrategy,
+    pub command_line_args: Vec<String>,
 }
 
 #[derive(Clone, Deserialize)]

--- a/v2/robotmk/src/config/internal.rs
+++ b/v2/robotmk/src/config/internal.rs
@@ -84,8 +84,7 @@ mod tests {
         SuiteConfig {
             robot_framework_config: RobotFrameworkConfig {
                 robot_target: Utf8PathBuf::from("/suite/system/tasks.robot"),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Incremental,
             },
             execution_config: ExecutionConfig {
@@ -102,8 +101,7 @@ mod tests {
         SuiteConfig {
             robot_framework_config: RobotFrameworkConfig {
                 robot_target: Utf8PathBuf::from("/suite/rcc/tasks.robot"),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Complete,
             },
             execution_config: ExecutionConfig {
@@ -155,8 +153,7 @@ mod tests {
             suites[0].robot_framework_config,
             RobotFrameworkConfig {
                 robot_target: Utf8PathBuf::from("/suite/rcc/tasks.robot"),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Complete,
             },
         );
@@ -192,8 +189,7 @@ mod tests {
             suites[1].robot_framework_config,
             RobotFrameworkConfig {
                 robot_target: Utf8PathBuf::from("/suite/system/tasks.robot"),
-                variable_file: None,
-                argument_file: None,
+                command_line_args: vec![],
                 retry_strategy: RetryStrategy::Incremental,
             },
         );


### PR DESCRIPTION
This replaces the existing options `argument_file` and `variable_file` and paves the way for allowing the user to configure further command line arguments in the bakery.

CMK-14941