### PR TITLE
Rename `n_retries_max` --> `n_attempts_max`

### DIFF
--- a/v2/data/google-imagesearch/config.json
+++ b/v2/data/google-imagesearch/config.json
@@ -9,7 +9,7 @@
 				"command_line_args": []
 			},
 			"execution_config": {
-				"n_retries_max": 1,
+				"n_attempts_max": 1,
 				"retry_strategy": "Incremental",
 				"execution_interval_seconds": 120,
 				"timeout": 110

--- a/v2/data/retry_rcc/windows.json
+++ b/v2/data/retry_rcc/windows.json
@@ -9,7 +9,7 @@
 				"command_line_args": ["--variablefile", "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml"]
 			},
 			"execution_config": {
-				"n_retries_max": 1,
+				"n_attempts_max": 1,
 				"retry_strategy": "Incremental",
 				"execution_interval_seconds": 10,
 				"timeout": 5

--- a/v2/data/retry_suite/windows.json
+++ b/v2/data/retry_suite/windows.json
@@ -8,7 +8,7 @@
 				"command_line_args": ["--variablefile", "C:\\robotmk\\v2\\data\\retry_suite\\retry_variables.yaml"]
 			},
 			"execution_config": {
-				"n_retries_max": 1,
+				"n_attempts_max": 1,
 				"retry_strategy": "Incremental",
 				"execution_interval_seconds": 10,
 				"timeout": 5

--- a/v2/data/web-store-order-processor/config.json
+++ b/v2/data/web-store-order-processor/config.json
@@ -9,7 +9,7 @@
 				"command_line_args": []
 			},
 			"execution_config": {
-				"n_retries_max": 1,
+				"n_attempts_max": 1,
 				"retry_strategy": "Incremental",
 				"execution_interval_seconds": 120,
 				"timeout": 110

--- a/v2/robotmk/src/bin/scheduler/attempt.rs
+++ b/v2/robotmk/src/bin/scheduler/attempt.rs
@@ -23,7 +23,7 @@ impl RetrySpec<'_> {
     }
 
     pub fn attempts(&self) -> impl Iterator<Item = Attempt> + '_ {
-        (0..self.execution_config.n_retries_max).map(|i| Attempt {
+        (0..self.execution_config.n_attempts_max).map(|i| Attempt {
             output_directory: self.output_directory(),
             identifier: &self.identifier,
             index: i,
@@ -200,7 +200,7 @@ mod tests {
             },
             working_directory: &Utf8PathBuf::from("/tmp/outputdir/suite_1"),
             execution_config: &ExecutionConfig {
-                n_retries_max: 2,
+                n_attempts_max: 2,
                 retry_strategy: RetryStrategy::Incremental,
                 execution_interval_seconds: 600,
                 timeout: 300,

--- a/v2/robotmk/src/bin/scheduler/config/external.rs
+++ b/v2/robotmk/src/bin/scheduler/config/external.rs
@@ -36,7 +36,7 @@ pub struct RobotFrameworkConfig {
 #[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ExecutionConfig {
-    pub n_retries_max: usize,
+    pub n_attempts_max: usize,
     pub retry_strategy: RetryStrategy,
     pub execution_interval_seconds: u32,
     pub timeout: u64,

--- a/v2/robotmk/src/bin/scheduler/config/internal.rs
+++ b/v2/robotmk/src/bin/scheduler/config/internal.rs
@@ -94,7 +94,7 @@ mod tests {
                 command_line_args: vec![],
             },
             execution_config: ExecutionConfig {
-                n_retries_max: 1,
+                n_attempts_max: 1,
                 retry_strategy: RetryStrategy::Incremental,
                 execution_interval_seconds: 300,
                 timeout: 60,
@@ -112,7 +112,7 @@ mod tests {
                 command_line_args: vec![],
             },
             execution_config: ExecutionConfig {
-                n_retries_max: 1,
+                n_attempts_max: 1,
                 retry_strategy: RetryStrategy::Complete,
                 execution_interval_seconds: 300,
                 timeout: 60,
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(
             suites[0].execution_config,
             ExecutionConfig {
-                n_retries_max: 1,
+                n_attempts_max: 1,
                 retry_strategy: RetryStrategy::Complete,
                 execution_interval_seconds: 300,
                 timeout: 60,
@@ -193,7 +193,7 @@ mod tests {
         assert_eq!(
             suites[1].execution_config,
             ExecutionConfig {
-                n_retries_max: 1,
+                n_attempts_max: 1,
                 retry_strategy: RetryStrategy::Incremental,
                 execution_interval_seconds: 300,
                 timeout: 60,


### PR DESCRIPTION
The latter is more concise. `n_retries_max` could be interpreted as not including the first attempt (since the first one is not a retry but a "try").