### PR TITLE
Suite results: Include more data

### DIFF
--- a/v2/robotmk/src/bin/scheduler/results.rs
+++ b/v2/robotmk/src/bin/scheduler/results.rs
@@ -116,6 +116,7 @@ pub enum ExecutionReport {
 pub struct AttemptsOutcome {
     pub attempts: Vec<AttemptOutcome>,
     pub rebot: Option<RebotOutcome>,
+    pub config: AttemptsConfig,
 }
 
 #[derive(Serialize)]
@@ -138,4 +139,12 @@ pub enum RebotOutcome {
 pub struct RebotResult {
     pub xml: String,
     pub html_base64: String,
+    pub timestamp: i64,
+}
+
+#[derive(Serialize)]
+pub struct AttemptsConfig {
+    pub interval: u32,
+    pub timeout: u64,
+    pub n_attempts_max: usize,
 }

--- a/v2/robotmk/src/bin/scheduler/scheduling/suites.rs
+++ b/v2/robotmk/src/bin/scheduler/scheduling/suites.rs
@@ -1,6 +1,8 @@
 use crate::environment::ResultCode;
 use crate::internal_config::Suite;
-use crate::results::{AttemptOutcome, AttemptsOutcome, ExecutionReport, SuiteExecutionReport};
+use crate::results::{
+    AttemptOutcome, AttemptsConfig, AttemptsOutcome, ExecutionReport, SuiteExecutionReport,
+};
 use crate::rf::{rebot::Rebot, robot::Attempt};
 use crate::sessions::session::{RunOutcome, RunSpec};
 
@@ -91,6 +93,11 @@ fn produce_suite_results(suite: &Suite) -> Result<AttemptsOutcome> {
                 }
                 .rebot(),
             )
+        },
+        config: AttemptsConfig {
+            interval: suite.execution_interval_seconds,
+            timeout: suite.timeout,
+            n_attempts_max: suite.robot.n_attempts_max,
         },
     })
 }


### PR DESCRIPTION
The following data will be needed on the server side for computing check results:
* Timestamp when merged XML (rebot) was created. We explicitly don't use timestamps contained in the XML because these timestamps do not include timezone information, which can lead to issues if the Checkmk server is in a different timezone.
* execution interval
* timeout
* maximum number of attempts