### PR TITLE
test termination 14: create integration test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,9 @@ jobs:
       - run: cargo test --all-targets --target ${{ matrix.type.target }} -- --skip test_scheduler
         working-directory: ${{ github.workspace }}/v2/robotmk/
 
+      - run: cargo run --example termination --target ${{ matrix.type.target }}
+        working-directory: ${{ github.workspace }}/v2/robotmk/
+
       - run: cargo clippy --all-targets --target ${{ matrix.type.target }} -- --deny warnings
         working-directory: ${{ github.workspace }}/v2/robotmk/
 

--- a/ci
+++ b/ci
@@ -21,9 +21,13 @@ main() {
 		cargo test --manifest-path "${cargo_toml_path}" --all-targets --target "${target}"
 		;;
 
+	'cargo-examples')
+		cargo run --manifest-path "${cargo_toml_path}" --example termination
+		;;
+
 	'check-all')
 		exit_code=0
-		for rust_step in fmt-check clippy test-unit
+		for rust_step in fmt-check clippy test-unit examples
 		do
 			"${self}" "cargo-${rust_step}"
 			exit_code=$(( exit_code + $? ))

--- a/v2/robotmk/examples/termination/.gitignore
+++ b/v2/robotmk/examples/termination/.gitignore
@@ -1,0 +1,3 @@
+log.html
+output.xml
+report.html

--- a/v2/robotmk/examples/termination/lib/create_child.py
+++ b/v2/robotmk/examples/termination/lib/create_child.py
@@ -1,0 +1,8 @@
+import subprocess
+
+
+def spawn(file_name: str) -> None:
+    with subprocess.Popen(["python", "-c", "import time; time.sleep(3)"]) as process:
+        with open(file_name, "w", encoding="utf-8") as file:
+            print(process.pid, file=file)
+        process.wait(3)

--- a/v2/robotmk/examples/termination/main.rs
+++ b/v2/robotmk/examples/termination/main.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use robotmk::config::RetryStrategy;
+use robotmk::environment::{Environment, SystemEnvironment};
+use robotmk::rf::robot::Robot;
+use robotmk::sessions::session::{CurrentSession, Session};
+use robotmk::suites::run_attempts_with_rebot;
+use std::collections::{HashMap, HashSet};
+use std::env::var;
+use std::thread;
+use std::time::Duration;
+use sysinfo::{get_current_pid, Pid, Process, ProcessExt, ProcessStatus, System, SystemExt};
+use tempfile::tempdir;
+use tokio_util::sync::CancellationToken;
+
+fn get_children(processes: &HashMap<Pid, Process>, pid: &Pid) -> HashSet<Pid> {
+    processes
+        .iter()
+        .filter_map(|(child_pid, process)| {
+            (process.parent().as_ref() == Some(pid)).then_some(*child_pid)
+        })
+        .collect()
+}
+
+fn print_process_tree(depth: usize, processes: &HashMap<Pid, Process>, pid: Pid) {
+    println!(
+        "{}{pid} {:?}",
+        "-".repeat(depth),
+        processes.get(&pid).unwrap().status()
+    );
+    for child in get_children(processes, &pid) {
+        print_process_tree(depth + 1, processes, child);
+    }
+}
+
+fn get_tree_size(processes: &HashMap<Pid, Process>, pid: Pid) -> usize {
+    let mut count = 0;
+    let status = processes.get(&pid).unwrap().status();
+    match status {
+        ProcessStatus::Zombie => {}
+        _ => count += 1,
+    };
+    for child in get_children(processes, &pid) {
+        count += get_tree_size(processes, child);
+    }
+    count
+}
+
+fn check_tree_size(system: &mut System, pid: Pid) -> usize {
+    system.refresh_processes();
+    let processes = system.processes();
+    println!("Process tree");
+    print_process_tree(0, processes, pid);
+    get_tree_size(processes, pid)
+}
+
+fn main() -> Result<()> {
+    let mut system = System::new();
+    let current_pid = get_current_pid().unwrap();
+    let cargo_manifest_dir = Utf8PathBuf::from(var("CARGO_MANIFEST_DIR")?);
+    let test_dir = Utf8PathBuf::from_path_buf(tempdir()?.into_path()).unwrap();
+    let flag_file = test_dir.join("flag_file");
+    let robot = Robot {
+        robot_target: cargo_manifest_dir.join("examples/termination/tasks.robot"),
+        n_attempts_max: 1,
+        command_line_args: vec!["--variable".into(), format!("FLAG_FILE:{flag_file}")],
+        retry_strategy: RetryStrategy::Complete,
+    };
+    let token = CancellationToken::new();
+    let thread_token = token.clone();
+    let running = thread::spawn(move || {
+        run_attempts_with_rebot(
+            &robot,
+            "test",
+            &Environment::System(SystemEnvironment {}),
+            &Session::Current(CurrentSession {}),
+            3,
+            &thread_token,
+            &test_dir,
+        )
+    });
+    while !flag_file.exists() {
+        // Wait for all children to be created
+        thread::sleep(Duration::from_millis(250));
+        if running.is_finished() {
+            panic!("{:?}", running.join());
+        }
+    }
+    assert_eq!(check_tree_size(&mut system, current_pid), 3);
+    token.cancel();
+    match running.join().unwrap() {
+        Err(error) => {
+            let message = format!("{error:?}");
+            assert!(message.starts_with("Terminated"), "Message: {message}")
+        }
+        ok => panic!("Cancellation failed: {ok:?}"),
+    };
+    assert_eq!(check_tree_size(&mut system, current_pid), 1);
+    Ok(())
+}

--- a/v2/robotmk/examples/termination/tasks.robot
+++ b/v2/robotmk/examples/termination/tasks.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Library             ${CURDIR}/lib/create_child.py
+
+*** Test Cases ***
+Spawn Child
+    create_child.spawn  ${FLAG_FILE}

--- a/v2/robotmk/src/results.rs
+++ b/v2/robotmk/src/results.rs
@@ -85,13 +85,13 @@ pub enum AttemptOutcome {
     OtherError(String),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub enum RebotOutcome {
     Ok(RebotResult),
     Error(String),
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct RebotResult {
     pub xml: String,
     pub html_base64: String,


### PR DESCRIPTION
This test runs as an [[example]]. Otherwise, we cannot ensure that are no other child processes belong to the running process. This is needed since we test the number of child processes.

This is the final change.

CMK-15433