### PR TITLE
Fix mixup of timeout and termination when running tasks

### DIFF
--- a/v2/robotmk/src/sessions/schtasks.rs
+++ b/v2/robotmk/src/sessions/schtasks.rs
@@ -21,12 +21,12 @@ async fn wait_for_task_exit(task: &TaskSpec, paths: &Paths) -> Result<RunOutcome
     match waited(duration, task.cancellation_token, queried).await {
         Outcome::Cancel => {
             kill_and_delete_task(task.task_name, paths);
-            Ok(RunOutcome::TimedOut)
+            Ok(RunOutcome::Terminated)
         }
         Outcome::Timeout => {
             error!("Timeout");
             kill_and_delete_task(task.task_name, paths);
-            Ok(RunOutcome::Terminated)
+            Ok(RunOutcome::TimedOut)
         }
         Outcome::Completed(Err(e)) => {
             kill_and_delete_task(task.task_name, paths);


### PR DESCRIPTION
This had the effect that no results were produced for suites with timeouts.