### PR TITLE
`sysinfo::System`: Use `new` instead of `new_all`

### DIFF
--- a/v2/robotmk/src/termination.rs
+++ b/v2/robotmk/src/termination.rs
@@ -48,7 +48,7 @@ where
 // non-direct children further down the tree to our child. However, Windows offers no API for this
 // (there is no SIGTERM on Windows), so we instead kill the entire tree.
 pub fn kill_process_tree(top_pid: &Pid) {
-    let mut system = System::new_all();
+    let mut system = System::new();
     system.refresh_processes();
     let processes = system.processes();
 


### PR DESCRIPTION
We anyway refresh the process list, so there is no need to load everything.