### PR TITLE
vagrant: minor tweaks

### DIFF
--- a/vagrant/playbook_variables.yaml
+++ b/vagrant/playbook_variables.yaml
@@ -1,6 +1,6 @@
 checkmk_agent_version: '2.2.0p8'
 checkmk_agent_edition: 'cee'
-checkmk_agent_protocol: 'http'
+checkmk_agent_server_protocol: 'http'
 checkmk_agent_server: '192.168.56.1'
 checkmk_agent_server_validate_certs: false
 checkmk_agent_port: 6556

--- a/vagrant/scripts/provision.ps1
+++ b/vagrant/scripts/provision.ps1
@@ -1,3 +1,3 @@
 iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
-choco install -y --force googlechrome
-choco install -y --force python
+choco install -y googlechrome
+choco install -y python


### PR DESCRIPTION
* The `checkmk_agent_protocol` variable was renamed in an update of the
 `checkmk.general` ansible collection.
* The chocolatey docs recommend against using `--force`, see https://docs.chocolatey.org/en-us/choco/commands/