### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/checks/robotmk.py
+++ b/checks/robotmk.py
@@ -1190,7 +1190,7 @@ def lns(src, dest):
 def perfdata_label(name):
     """Removes unwanted characters from the instring.
     Replaces separators by underscores."""
-    unwanted_chars = '<>:"/\?*'
+    unwanted_chars = '<>:"/\\?*'
     separators = "-_| "
     for c in unwanted_chars:
         name = name.replace(c, "")
@@ -1210,13 +1210,13 @@ def xstr(s):
 def remove_nasty_chars(instr):
     # Replace all chars which can cause problem in Multisite
     # no quotes, no brackets
-    outstr = re.sub("[\[\]?+*@{}'\"]", "", xstr(instr))
+    outstr = re.sub("[\\[\\]?+*@{}'\"]", "", xstr(instr))
     outstr = outstr.replace("$", "")
     outstr = outstr.replace("\\", "")
     # Newlines better replace by space
     outstr = outstr.replace("\n", " ")
     # dash for pipe
-    outstr = re.sub("\|", "-", outstr)
+    outstr = re.sub("\\|", "-", outstr)
     return outstr
 
 
@@ -1339,7 +1339,7 @@ def html_to_text(html):
     Given a piece of HTML, return the plain text it contains.
     """
     # Remove Prefix
-    html = re.sub("\*HTML\* ", "", html)
+    html = re.sub("\\*HTML\\* ", "", html)
     html = re.sub(
         '<span class="merge">Test has been re-executed and results merged.</span>',
         "Test result after re-execution: ",


### PR DESCRIPTION
In Python 3 the character \ is used to escape unicode characters. Thus, the following syntax
```
"\\|"
```
is not valid. This is the corresponding documentation.
```
Changed in version 3.6: Unrecognized escape sequences produce a
DeprecationWarning. In a future Python version they will be a
SyntaxWarning and eventually a SyntaxError.
```

CMK-15744