### PR TITLE
rmk: Adjust scheduler for core mode (no-op)

### DIFF
--- a/src/bin/scheduler/internal_config.rs
+++ b/src/bin/scheduler/internal_config.rs
@@ -176,10 +176,10 @@ mod tests {
                 results_directory: Utf8PathBuf::from("/results"),
                 rcc_config: RCCConfig {
                     binary_path: Utf8PathBuf::from("/bin/rcc"),
-                    profile_config: RCCProfileConfig::Custom(CustomRCCProfileConfig {
+                    profile_config: Some(RCCProfileConfig::Custom(CustomRCCProfileConfig {
                         name: "Robotmk".into(),
                         path: "/rcc_profile_robotmk.yaml".into(),
-                    }),
+                    })),
                 },
                 suite_groups: vec![
                     SequentialSuiteGroup {
@@ -201,10 +201,10 @@ mod tests {
             global_config.rcc_config,
             RCCConfig {
                 binary_path: Utf8PathBuf::from("/bin/rcc"),
-                profile_config: RCCProfileConfig::Custom(CustomRCCProfileConfig {
+                profile_config: Some(RCCProfileConfig::Custom(CustomRCCProfileConfig {
                     name: "Robotmk".into(),
                     path: "/rcc_profile_robotmk.yaml".into(),
-                }),
+                })),
             }
         );
         assert_eq!(suites.len(), 2);

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RCCConfig {
     pub binary_path: Utf8PathBuf,
-    pub profile_config: RCCProfileConfig,
+    pub profile_config: Option<RCCProfileConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/tests/test_scheduler.rs
+++ b/tests/test_scheduler.rs
@@ -29,7 +29,9 @@ async fn test_scheduler() -> AnyhowResult<()> {
             .join("minimal_suite"),
         RCCConfig {
             binary_path: var("RCC_BINARY_PATH")?.into(),
-            profile_config: RCCProfileConfig::Custom(create_custom_rcc_profile(&test_dir)?),
+            profile_config: Some(RCCProfileConfig::Custom(create_custom_rcc_profile(
+                &test_dir,
+            )?)),
         },
         &current_user_name,
     );
@@ -310,7 +312,8 @@ async fn assert_rcc_files_permissions(
     headed_user_name: &str,
 ) -> AnyhowResult<()> {
     assert_permissions(&rcc_config.binary_path, &format!("{headed_user_name}:(RX)")).await?;
-    let RCCProfileConfig::Custom(custom_rcc_profile_config) = &rcc_config.profile_config else {
+    let Some(RCCProfileConfig::Custom(custom_rcc_profile_config)) = &rcc_config.profile_config
+    else {
         return Ok(());
     };
     assert_permissions(
@@ -329,7 +332,7 @@ async fn assert_rcc_configuration(rcc_config: &RCCConfig) -> AnyhowResult<()> {
     assert!(stdout.contains("telemetry-enabled                     ...  \"false\""));
     assert!(stdout.contains("holotree-shared                       ...  \"true\""));
     assert!(stdout.contains("holotree-global-shared                ...  \"true\""));
-    if let RCCProfileConfig::Custom(custom_rcc_profile_config) = &rcc_config.profile_config {
+    if let Some(RCCProfileConfig::Custom(custom_rcc_profile_config)) = &rcc_config.profile_config {
         assert!(stdout.contains(&format!(
             "config-active-profile                 ...  \"{}\"",
             custom_rcc_profile_config.name


### PR DESCRIPTION
`RCCProfileConfig` is now optional. If the value is `None`, skip RCC profile configuration.