### PR TITLE
Rename agent sections to avoid crashes in Checkmk

### DIFF
--- a/src/bin/agent_plugin.rs
+++ b/src/bin/agent_plugin.rs
@@ -40,7 +40,7 @@ fn config_path_from_env() -> Result<Utf8PathBuf, String> {
 fn report_config_section(section: &ConfigSection) {
     let section_serialized =
         serde_json::to_string(section).expect("Unexpected serialization error: ConfigSection");
-    println!("<<<robotmk_config:sep(0)>>>");
+    println!("<<<robotmk_config_v2:sep(0)>>>");
     println!("{section_serialized}");
 }
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -46,7 +46,7 @@ pub struct RCCSetupFailures {
 
 impl WriteSection for RCCSetupFailures {
     fn name() -> &'static str {
-        "robotmk_rcc_setup_failures"
+        "robotmk_rcc_setup_failures_v2"
     }
 }
 


### PR DESCRIPTION
* `robotmk_config` --> `robotmk_config_v2`
* `robotmk_rcc_setup_failures` --> `robotmk_rcc_setup_failures_v2`

CMK-17005
CMK-17008