### PR TITLE
Clean up working directory upon startup

### DIFF
--- a/src/bin/scheduler/setup/general.rs
+++ b/src/bin/scheduler/setup/general.rs
@@ -33,6 +33,9 @@ pub fn setup(global_config: &GlobalConfig, plans: Vec<Plan>) -> AnyhowResult<Vec
 }
 
 fn setup_working_directories(working_directory: &Utf8Path, plans: &[Plan]) -> AnyhowResult<()> {
+    if working_directory.exists() {
+        remove_dir_all(working_directory).context("Failed to remove working directory")?;
+    }
     create_dir_all(working_directory).context("Failed to create working directory")?;
     for plan in plans {
         create_dir_all(&plan.working_directory).context(format!(


### PR DESCRIPTION
Before, the working directories of suites that are not configured anymore stayed behind.