### PR TITLE
Replace icacls.exe with WinAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 
 [[package]]
 name = "cfg-if"
@@ -345,9 +345,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "errno"
@@ -357,6 +357,17 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -581,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -833,6 +844,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "faccess",
  "flate2",
  "flexi_logger",
  "fs4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ camino = { version = "1.1.6", features = ["serde1"] }
 chrono = "0.4.31"
 clap = { version = "4.4.13", features = ["derive"] }
 ctrlc = "3.4.2"
+faccess = "0.2.4"
 flate2 = "1.0.30"
 flexi_logger = "0.27.3"
 fs4 = "0.7.0"
@@ -33,6 +34,7 @@ features = [
     "Win32_System_Ole",
     "Win32_Foundation",
     "Win32_System_Variant",
+    "Win32_Security_Authorization",
 ]
 
 [dev-dependencies]

--- a/examples/perm.rs
+++ b/examples/perm.rs
@@ -1,0 +1,102 @@
+#![cfg(windows)]
+use camino::Utf8Path;
+use std::fs::{create_dir, remove_dir_all};
+use std::process::Command;
+
+use std::ffi::OsStr;
+use std::ops::{Deref, DerefMut};
+use std::os::windows::ffi::OsStrExt;
+use windows::core::{HSTRING, PCWSTR, PWSTR};
+use windows::Win32::Foundation::{LocalFree, GENERIC_ALL, HLOCAL};
+use windows::Win32::Security::Authorization::{
+    SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W, NO_MULTIPLE_TRUSTEE, SET_ACCESS,
+    SE_FILE_OBJECT, TRUSTEE_IS_NAME, TRUSTEE_IS_USER, TRUSTEE_W,
+};
+use windows::Win32::Security::{ACL, DACL_SECURITY_INFORMATION, NO_INHERITANCE};
+
+#[repr(transparent)]
+pub struct OwnedLocalAlloc<T>(pub T);
+
+impl<T> Default for OwnedLocalAlloc<T> {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+impl<T> Drop for OwnedLocalAlloc<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let ptr: HLOCAL = std::mem::transmute_copy(self);
+            if !ptr.0.is_null() {
+                let _ = LocalFree(ptr);
+            }
+        }
+    }
+}
+
+impl<T> Deref for OwnedLocalAlloc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for OwnedLocalAlloc<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+fn print_permissions(path: &Utf8Path) {
+    let mut icacls_command = Command::new("icacls.exe");
+    icacls_command.arg(path);
+    let output = String::from_utf8(icacls_command.output().unwrap().stdout).unwrap();
+    println!("\n{output}");
+}
+
+fn main() {
+    // Input
+    let user = "vagrant";
+    let path = Utf8Path::new("C:\\Users\\vagrant\\Desktop\\t");
+
+    // Reset
+    if path.exists() {
+        remove_dir_all(path).unwrap();
+    }
+    create_dir(path).unwrap();
+
+    print_permissions(path);
+
+    let mut newdacl = OwnedLocalAlloc::<*mut ACL>::default();
+    let mut os_user: Vec<u16> = OsStr::new(user).encode_wide().chain([0]).collect();
+    let ea = [EXPLICIT_ACCESS_W {
+        grfAccessPermissions: GENERIC_ALL.0,
+        grfAccessMode: SET_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: std::ptr::null_mut(),
+            MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+            TrusteeForm: TRUSTEE_IS_NAME,
+            TrusteeType: TRUSTEE_IS_USER,
+            ptstrName: PWSTR(os_user.as_mut_ptr()),
+        },
+    }];
+
+    unsafe { SetEntriesInAclW(Some(&ea), None, &mut *newdacl) }.unwrap();
+    println!("{:?}\n", unsafe { **newdacl });
+    unsafe {
+        SetNamedSecurityInfoW(
+            PCWSTR(HSTRING::from(path.as_std_path()).as_ptr()),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(*newdacl as *const _),
+            None,
+        )
+    }
+    .unwrap();
+
+    print_permissions(path);
+}

--- a/vagrant/f12.sh
+++ b/vagrant/f12.sh
@@ -17,9 +17,10 @@ hostname=default
 vagrant ssh-config > "$sshconfig"
 
 # Sync rust binaries to vagrant machine (scheduler and agent plugin)
-(cd "$topdir"; cargo build --target=x86_64-pc-windows-gnu)
-sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/target/x86_64-pc-windows-gnu/debug/robotmk_scheduler.exe vagrant@"$hostname":"$agentbindir"
-sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/target/x86_64-pc-windows-gnu/debug/robotmk_agent_plugin.exe vagrant@"$hostname":"$agentplugindir"
+(cd "$topdir"; cargo build --example perm --target=x86_64-pc-windows-gnu)
+sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/target/x86_64-pc-windows-gnu/debug/examples/perm.exe vagrant@"$hostname":"$agentbindir"
+sshpass -p "vagrant" ssh -F "$sshconfig" "$hostname" "${agentbindir}/perm.exe"
+# sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/target/x86_64-pc-windows-gnu/debug/robotmk_agent_plugin.exe vagrant@"$hostname":"$agentplugindir"
 
 # Sync config for agent plugin to vagrant machine
-sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/data/retry_rcc/windows.json vagrant@"$hostname":"$agentconfigdir"/robotmk.json
+# sshpass -p "vagrant" scp -F "$sshconfig" "$topdir"/data/retry_rcc/windows.json vagrant@"$hostname":"$agentconfigdir"/robotmk.json


### PR DESCRIPTION
CMK-17607

Some more testing revealed, that we don't actually need `GetNamedSecurityInfoW`. I am not sure why it is shown by Windows documentation (all links in commit). This cuts done the size of the change by half, which is already much better.

Also, it appears that `SetNamedSecurityInfoW` is used much more frequently than `icacls.exe`. So maybe we should reconsider adding this.
