### PR TITLE
Improve some error messages

### DIFF
--- a/src/bin/scheduler/build.rs
+++ b/src/bin/scheduler/build.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum BuildError {
-    #[error("Failed to `{0}`")]
+    #[error("{0}")]
     Unrecoverable(String),
     #[error("Terminated")]
     Cancelled,

--- a/src/bin/scheduler/setup/general.rs
+++ b/src/bin/scheduler/setup/general.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SetupError {
-    #[error("Failed to `{0}`")]
+    #[error("{0}")]
     Unrecoverable(String),
     #[error("Terminated")]
     Cancelled,

--- a/src/section.rs
+++ b/src/section.rs
@@ -25,7 +25,7 @@ pub struct Section {
 
 #[derive(Error, Debug)]
 pub enum WriteError {
-    #[error("Failed to `{0}`")]
+    #[error("{0}")]
     Unrecoverable(String),
     #[error("Terminated")]
     Cancelled,


### PR DESCRIPTION
Remove "Failed to ..." prefix, since the underlying error messages are not tailored to this prefix.