### PR TITLE
RCC setup: Fix crash if no plans for current session are configured

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -32,7 +32,7 @@ impl WriteSection for SetupFailures {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct SetupFailure {
     pub plan_id: String,
     pub summary: String,


### PR DESCRIPTION
Long path support is always enabled in the current session. If no plans for the current session were configured, attempting to enable long path support crashed because the directory for the stdio files was missing.

CMK-18570