### PR TITLE
RCC setup: Fix crash if no plans for current session are configured

### DIFF
--- a/src/bin/scheduler/setup/general.rs
+++ b/src/bin/scheduler/setup/general.rs
@@ -122,7 +122,7 @@ fn setup_with_one_directory_per_user(
         return (surviving_plans, failures);
     }
     for (session, plans_in_session) in plans_by_sessions(plans) {
-        let user_target = &target.join(&session.id());
+        let user_target = &target.join(session.id());
         if let Err(e) = create_dir_all(user_target) {
             let error = anyhow!(e).context(format!(
                 "Failed to create directory {} for session {}",


### PR DESCRIPTION
Long path support is always enabled in the current session. If no plans for the current session were configured, attempting to enable long path support crashed because the directory for the stdio files was missing.

CMK-18570