### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: "Compute release tag"
         id: compute-tag
         run: |
-            version="$(cargo run --bin robotmk_scheduler -- --version | cut --delimiter " " --fields 2)"
+            version="$(RUSTFLAGS="--cfg tokio_unstable" cargo run --bin robotmk_scheduler -- --version | cut --delimiter " " --fields 2)"
             echo "TAG=v${version}" >> "${GITHUB_OUTPUT}"
 
       - name: "Push release tag"


### PR DESCRIPTION
We temporarily need to add the `--cfg tokio_unstable` flag. Once we release the scheduler for Linux, this won't be needed anymore in the release script. Instead of building the scheduler there to query the version, we will use the already built binary.