### PR TITLE
Fix error formatting

### DIFF
--- a/src/bin/scheduler/build.rs
+++ b/src/bin/scheduler/build.rs
@@ -94,8 +94,8 @@ fn run_build_command(
                 "Environment building failed, plan {id} will be dropped. See {} for stdio logs",
                 run_spec.base_path,
             ));
-            error!("{log_error:#?}");
-            return Ok(BuildOutcome::Error(format!("{log_error:#?}")));
+            error!("{log_error:?}");
+            return Ok(BuildOutcome::Error(format!("{log_error:?}")));
         }
     };
     let duration = (Utc::now() - reference_timestamp_for_duration).num_seconds();

--- a/src/bin/scheduler/logging.rs
+++ b/src/bin/scheduler/logging.rs
@@ -44,6 +44,6 @@ pub fn init(
 }
 
 pub fn log_and_return_error(error: Error) -> Error {
-    error!("{error:#?}");
+    error!("{error:?}");
     error
 }

--- a/src/bin/scheduler/scheduling/scheduler.rs
+++ b/src/bin/scheduler/scheduling/scheduler.rs
@@ -43,7 +43,7 @@ pub async fn run_plans_and_cleanup(global_config: &GlobalConfig, plans: &[Plan])
     error!("Received termination signal while scheduling, waiting for plans to terminate");
     while let Some(outcome) = join_set.join_next().await {
         if let Err(error) = outcome {
-            error!("{error:#?}");
+            error!("{error:?}");
         }
     }
 }

--- a/src/bin/scheduler/setup/general.rs
+++ b/src/bin/scheduler/setup/general.rs
@@ -61,13 +61,13 @@ fn setup_plans_working_directory(plans: Vec<Plan>) -> (Vec<Plan>, Vec<SetupFailu
             let error = anyhow!(e);
             error!(
                 "Plan {}: Failed to create working directory. Plan won't be scheduled.
-                 Error: {error:#?}",
+                 Error: {error:?}",
                 plan.id
             );
             failures.push(SetupFailure {
                 plan_id: plan.id.clone(),
                 summary: "Failed to create working directory".to_string(),
-                details: format!("{error:#?}"),
+                details: format!("{error:?}"),
             });
             continue;
         }
@@ -88,13 +88,13 @@ fn setup_plans_working_directory(plans: Vec<Plan>) -> (Vec<Plan>, Vec<SetupFailu
                     error!(
                         "Plan {}: Failed to set permissions for working directory. \
                          Plan won't be scheduled.
-                         Error: {error:#?}",
+                         Error: {error:?}",
                         plan.id
                     );
                     failures.push(SetupFailure {
                         plan_id: plan.id.clone(),
                         summary: "Failed to set permissions for working directory".to_string(),
-                        details: format!("{error:#?}"),
+                        details: format!("{error:?}"),
                     });
                     continue;
                 };
@@ -166,13 +166,13 @@ fn setup_with_one_directory_per_user(
             error!(
                 "Plan {}: Failed to create {description_for_failure_reporting} directory. \
                  Plan won't be scheduled.
-                 Error: {error:#?}",
+                 Error: {error:?}",
                 plan.id
             );
             failures.push(SetupFailure {
                 plan_id: plan.id.clone(),
                 summary: format!("Failed to create {description_for_failure_reporting} directory"),
-                details: format!("{error:#?}"),
+                details: format!("{error:?}"),
             });
         }
         return (surviving_plans, failures);
@@ -185,13 +185,13 @@ fn setup_with_one_directory_per_user(
                 error!(
                     "Plan {}: Failed to create user-specific {description_for_failure_reporting} \
                      directory. Plan won't be scheduled.
-                     Error: {error:#?}",
+                     Error: {error:?}",
                     plan.id
                 );
                 failures.push(SetupFailure {
                     plan_id: plan.id.clone(),
                     summary: format!("Failed to create user-specific {description_for_failure_reporting} directory"),
-                    details: format!("{error:#?}"),
+                    details: format!("{error:?}"),
                 });
             }
             continue;
@@ -213,13 +213,13 @@ fn setup_with_one_directory_per_user(
                         error!(
                             "Plan {}: Failed to adjust permissions for user-specific \
                              {description_for_failure_reporting} directory. Plan won't be scheduled.
-                             Error: {error:#?}",
+                             Error: {error:?}",
                             plan.id
                         );
                         failures.push(SetupFailure {
                             plan_id: plan.id.clone(),
                             summary: format!("Failed to adjust permissions for user-specific {description_for_failure_reporting} directory"),
-                            details: format!("{error:#?}"),
+                            details: format!("{error:?}"),
                         });
                     }
                     continue;
@@ -278,13 +278,13 @@ fn setup_managed_directories(plans: Vec<Plan>) -> (Vec<Plan>, Vec<SetupFailure>)
                 let error = anyhow!(e);
                 error!(
                     "Plan {}: Failed to create managed directory. Plan won't be scheduled.
-                     Error: {error:#?}",
+                     Error: {error:?}",
                     plan.id
                 );
                 failures.push(SetupFailure {
                     plan_id: plan.id.clone(),
                     summary: "Failed to create managed directory".to_string(),
-                    details: format!("{error:#?}"),
+                    details: format!("{error:?}"),
                 });
                 continue;
             }
@@ -298,14 +298,14 @@ fn setup_managed_directories(plans: Vec<Plan>) -> (Vec<Plan>, Vec<SetupFailure>)
                     if let Err(error) = grant_full_access(&user_session.user_name, target) {
                         error!(
                             "Plan {}: Failed to adjust permissions of managed directory. Plan won't be scheduled.
-                             Error: {error:#?}",
+                             Error: {error:?}",
                             plan.id
                         );
                         failures.push(SetupFailure {
                             plan_id: plan.id.clone(),
                             summary: "Failed to adjust permissions of managed directory"
                                 .to_string(),
-                            details: format!("{error:#?}"),
+                            details: format!("{error:?}"),
                         });
                         continue;
                     }

--- a/src/bin/scheduler/setup/rcc.rs
+++ b/src/bin/scheduler/setup/rcc.rs
@@ -259,13 +259,13 @@ fn holotree_disable_sharing(
                 for plan in plans {
                     error!(
                         "Plan {}: Disabling RCC shared holotree failed. Plan won't be scheduled.
-                         Error: {error:#?}",
+                         Error: {error:?}",
                         plan.id,
                     );
                     failures.push(SetupFailure {
                         plan_id: plan.id.clone(),
                         summary: "Disabling RCC shared holotree failed".to_string(),
-                        details: format!("{error:#?}"),
+                        details: format!("{error:?}"),
                     });
                 }
             }
@@ -377,7 +377,7 @@ fn execute_run_spec_in_session(
         Ok(run_outcome) => run_outcome,
         Err(error) => {
             let error = log_and_return_error(error);
-            return Ok(Some(format!("{error:#?}")));
+            return Ok(Some(format!("{error:?}")));
         }
     };
     let exit_code = match run_outcome {

--- a/src/bin/scheduler/setup/unpack_managed.rs
+++ b/src/bin/scheduler/setup/unpack_managed.rs
@@ -27,13 +27,13 @@ pub fn setup(plans: Vec<Plan>) -> (Vec<Plan>, Vec<SetupFailure>) {
             if let Err(error) = unpack_into(tar_gz_path, target) {
                 error!(
                     "Plan {}: Failed to unpack managed source archive. Plan won't be scheduled.
-                     Error: {error:#?}",
+                     Error: {error:?}",
                     plan.id
                 );
                 failures.push(SetupFailure {
                     plan_id: plan.id.clone(),
                     summary: "Failed to unpack managed source archive".to_string(),
-                    details: format!("{error:#?}"),
+                    details: format!("{error:?}"),
                 });
                 continue;
             }

--- a/src/bin/scheduler/setup/windows_permissions.rs
+++ b/src/bin/scheduler/setup/windows_permissions.rs
@@ -52,7 +52,7 @@ pub fn grant_permissions_to_all_plan_users(
                         error!(
                             "Plan {}: Failed to adjust permissions of \
                              {description_for_failure_reporting} for plan user. Plan won't be scheduled.
-                             Error: {error:#?}",
+                             Error: {error:?}",
                             plan.id
                         );
                         failures.push(SetupFailure {
@@ -60,7 +60,7 @@ pub fn grant_permissions_to_all_plan_users(
                             summary: format!(
                                 "Failed to adjust permissions of {description_for_failure_reporting} for plan user"
                             ),
-                            details: format!("{error:#?}"),
+                            details: format!("{error:?}"),
                         });
                     }
                 }


### PR DESCRIPTION
`:#?` adds additional qutation marks which we don't need.