### PR TITLE
Include Linux binaries in release workflow & bump version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,15 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.9
-        with:
-          target: x86_64-unknown-linux-gnu
-          # By default, setup-rust-toolchain sets "-D warnings". As a side effect, the settings in
-          # .cargo/config.toml are ignored:
-          # https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
-          # "There are four mutually exclusive sources of extra flags"
-          rustflags: ""
-
       - uses: actions/download-artifact@v4
         with:
           name: rcc
@@ -37,12 +28,20 @@ jobs:
           name: rmk_windows64
           path: artifact/rmk_windows64/
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: rmk_linux64
+          path: artifact/rmk_linux64/
+
       - run: zip -r executables.zip artifact
 
       - name: "Compute release tag"
         id: compute-tag
         run: |
-            version="$(cargo run --bin robotmk_scheduler -- --version | cut --delimiter " " --fields 2)"
+            # file permissions are not retained during upload:
+            # https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+            chmod +x artifact/rmk_linux64/robotmk_scheduler
+            version="$(./artifact/rmk_linux64/robotmk_scheduler --version | cut --delimiter " " --fields 2)"
             echo "TAG=v${version}" >> "${GITHUB_OUTPUT}"
 
       - name: "Push release tag"

--- a/.github/workflows/robotmk_build.yaml
+++ b/.github/workflows/robotmk_build.yaml
@@ -4,7 +4,7 @@ name: "Build Robotmk"
 on:
   workflow_call: {}
 jobs:
-  build_robotmk:
+  build_windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,30 @@ jobs:
         with:
           name: rmk_windows64
           path: |
-            ${{ github.workspace }}/target/x86_64-pc-windows-gnu/release/robotmk_scheduler.exe
-            ${{ github.workspace }}/target/x86_64-pc-windows-gnu/release/robotmk_agent_plugin.exe
+            target/x86_64-pc-windows-gnu/release/robotmk_scheduler.exe
+            target/x86_64-pc-windows-gnu/release/robotmk_agent_plugin.exe
+          if-no-files-found: error
+
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9
+        with:
+          target: x86_64-unknown-linux-gnu
+          # By default, setup-rust-toolchain sets "-D warnings". As a side effect, the settings in
+          # .cargo/config.toml are ignored:
+          # https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+          # "There are four mutually exclusive sources of extra flags"
+          rustflags: ""
+
+      - run: cargo build --target=x86_64-unknown-linux-gnu --release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rmk_linux64
+          path: |
+            target/x86_64-unknown-linux-gnu/release/robotmk_scheduler
+            target/x86_64-unknown-linux-gnu/release/robotmk_agent_plugin
           if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "robotmk"
-version = "3.0.0-alpha-4"
+version = "3.0.0-alpha-5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robotmk"
-version = "3.0.0-alpha-4"
+version = "3.0.0-alpha-5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Also use the scheduler binary for Linux in the release workflow to query
the version.

CMK-18620