### PR TITLE
Don't allow Microsoft telemetry

### DIFF
--- a/.github/workflows/system_tests.yaml
+++ b/.github/workflows/system_tests.yaml
@@ -27,6 +27,12 @@ jobs:
           name: rcc
           path: C:\
 
+      # MSVC uses vctip.exe for telemetry. vctip.exe is started as a child of termination.exe. This
+      # can cause CI failures, if "vctip.exe" does not terminate before `get_children` is called.
+      # It is unclear why MSVC is running, despite target=x86_64-pc-windows-gnu. The following
+      # command is intended turn off telemetry via vctip.exe.
+      - shell: pwsh
+        run:  Get-ChildItem -Filter vctip.exe -Recurse "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC" | rm
       - run: cargo test --target=x86_64-pc-windows-gnu --test test_plan_run --test test_agent_plugin -- --ignored
       - run: cargo run --example termination --target=x86_64-pc-windows-gnu
       - run: cargo run --example termination --target=x86_64-pc-windows-gnu -- C:\windows64\rcc.exe


### PR DESCRIPTION
It is unclear why MSVC telemetry is running in the background, eventhough we are using the GNU toolchain. However, if don't turn it off, then we have flakes in `examples/termination/main.rs`.