### PR TITLE
Windows: Avoid permission issues when building envs. as non-privileged user

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -118,14 +118,12 @@ impl RCCEnvironment {
             build_command_spec
                 .add_env(String::from("RCC_REMOTE_ORIGIN"), remote_origin.to_string());
         }
-
-        let mut version_command_spec = Self::bundled_command_spec(&self.binary_path);
-        version_command_spec.add_argument("-v");
-
-        build_command_spec
-            .add_argument("--")
-            .add_argument(version_command_spec.executable)
-            .add_arguments(version_command_spec.arguments);
+        build_command_spec.add_argument("--").add_argument(
+            #[cfg(unix)]
+            "true",
+            #[cfg(windows)]
+            "cmd.exe",
+        );
 
         Some(BuildInstructions {
             import_command_spec,
@@ -210,9 +208,12 @@ mod tests {
             .add_argument("--space")
             .add_argument("my_plan")
             .add_argument("--")
-            .add_argument("/bin/rcc")
-            .add_argument("--bundled")
-            .add_argument("-v");
+            .add_argument(
+                #[cfg(unix)]
+                "true",
+                #[cfg(windows)]
+                "cmd.exe",
+            );
 
         assert_eq!(
             RCCEnvironment {


### PR DESCRIPTION
Previously, we built environments with the following command:
```
rcc task script -- rcc -v
                   ------
                   essentially a no-op
```

For unprivileged users, this can fail with:
```
####  Progress: 15/15  v17.18.0     1.201s  Fresh holotree done [with 7 workers on 8 CPUs].
Error: Access is denied.
[rcc] exit status will be: 7!
```

Before executing the command line handed over to `rcc task script`, RCC checks internally if the first value of the command line exists and tries to resolve it if it is a symlink:
https://github.com/robocorp/rcc/blob/db661af9d28a61a2dbc3656260de6c29dbe01bcd/operations/running.go#L276

This symlink resolution step (`filepath.EvalSymlinks`) apparently fails on Windows systems if the user has insufficient permissions to access the parent folders of the RCC binary, even if the binary is not even a symlink. Note that the unprivileged user has read and execute access to the RCC binary, otherwise, starting RCC in the first place would fail.

To solve this issue, we resort to a different no-op in the build step:
* Windows: `cmd.exe`
Note that it is unclear what commands are actually available here. For example, the echo command is available on Windows systems but cannot be found when used with `rcc task script`. However, inside a shell created with`rcc task shell`, the echo command works (and so does calling the RCC binary).

* Linux: `true`

Unfortunately, we have no good way of testing if running plans with an unprivileged user works, since we cannot create an additional user session in the GitHub actions.

CMK-20071