### PR TITLE
Grant plan users read access to the ROBOCORP_HOME base directory

### DIFF
--- a/src/bin/scheduler/setup/steps/run.rs
+++ b/src/bin/scheduler/setup/steps/run.rs
@@ -33,7 +33,7 @@ type Gatherer = fn(&GlobalConfig, Vec<Plan>) -> Vec<StepWithPlans>;
 #[cfg(unix)]
 type Steps = [(Gatherer, &'static str); 11];
 #[cfg(windows)]
-type Steps = [(Gatherer, &'static str); 17];
+type Steps = [(Gatherer, &'static str); 18];
 
 const STEPS: Steps = [
     (
@@ -44,6 +44,23 @@ const STEPS: Steps = [
     (
         directories::gather_robocorp_home_base,
         "ROBOCORP_HOME base directory",
+    ),
+    // It is unclear why this is needed. Without it, non-admin users cannot build RCC environments
+    // (with ROBOCORP_HOME set). Micromamba crashes with the following error:
+    // info     libmamba ****************** Backtrace Start ******************
+    // debug    libmamba Loading configuration
+    // trace    libmamba Compute configurable 'create_base'
+    // trace    libmamba Compute configurable 'no_env'
+    // trace    libmamba Compute configurable 'no_rc'
+    // trace    libmamba Compute configurable 'rc_files'
+    // trace    libmamba Compute configurable 'root_prefix'
+    // trace    libmamba Compute configurable 'envs_dirs'
+    // critical libmamba weakly_canonical: Access is denied.: "C:\rmk\rcc_home\vagrant2\envs"
+    // info     libmamba ****************** Backtrace End ********************
+    #[cfg(windows)]
+    (
+        directories::gather_robocorp_base_read_access,
+        "Read access to ROBOCORP_HOME base directory",
     ),
     #[cfg(windows)]
     (

--- a/tests/test_scheduler.rs
+++ b/tests/test_scheduler.rs
@@ -696,19 +696,15 @@ async fn assert_robocorp_home(
                 .lines()
                 .collect::<Vec<&str>>()
                 .len(),
-            3 // Administrator group + empty line + success message (suppressing the latter with /q does not seem to work)
+            4 // Administrator group + headed user name + empty line + success message (suppressing the latter with /q does not seem to work)
         );
         assert!(dacl_exists_for_sid(robocorp_home_base, "*S-1-5-32-544").await?);
-        assert!(
-            get_permissions(robocorp_home_base.join(format!("user_{headed_user_name}")))
-                .await?
-                .contains(&format!("{headed_user_name}:(OI)(CI)(F)",))
-        );
-        assert!(
-            get_permissions(robocorp_home_base.join(format!("user_{headed_user_name}")))
-                .await?
-                .contains(&format!("{headed_user_name}:(OI)(CI)(F)",))
-        );
+        assert_permissions(&robocorp_home_base, &format!("{headed_user_name}:(R)")).await?;
+        assert_permissions(
+            &robocorp_home_base.join(format!("user_{headed_user_name}")),
+            &format!("{headed_user_name}:(OI)(CI)(F)"),
+        )
+        .await?;
     }
     Ok(())
 }


### PR DESCRIPTION
As of now, only admin users have access to the ROBOCORP_HOME base directory on Windows systems, which is what we want. Furthermore, plan users are granted full access to their user-specific ROBOCORP_HOME directory (which is located inside the base directory). This setup is as desired. However, it turned out that this prevents non-admin plan users from building RCC environments. For some reason, read access to the ROBOCORP_HOME base directory is required. Without it, micromamba crashes:
```
info     libmamba ****************** Backtrace Start ******************
debug    libmamba Loading configuration
trace    libmamba Compute configurable 'create_base'
trace    libmamba Compute configurable 'no_env'
trace    libmamba Compute configurable 'no_rc'
trace    libmamba Compute configurable 'rc_files'
trace    libmamba Compute configurable 'root_prefix'
trace    libmamba Compute configurable 'envs_dirs'
critical libmamba weakly_canonical: Access is denied.: "C:\rmk\rcc_home\vagrant2\envs"
info     libmamba ****************** Backtrace End ********************
```