### PR TITLE
Remove targets from `rust-toolchain.toml` and re-add to Rust setup step

### DIFF
--- a/.github/workflows/robotmk_build.yaml
+++ b/.github/workflows/robotmk_build.yaml
@@ -11,6 +11,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
+          target: x86_64-pc-windows-msvc
           # By default, setup-rust-toolchain sets "-D warnings". As a side effect, the settings in
           # .cargo/config.toml are ignored:
           # https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags

--- a/.github/workflows/system_tests.yaml
+++ b/.github/workflows/system_tests.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
+          target: x86_64-pc-windows-msvc
           # By default, setup-rust-toolchain sets "-D warnings". As a side effect, the settings in
           # .cargo/config.toml are ignored:
           # https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
       - run: pip install -r requirements.txt
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
+          target: ${{ matrix.type.target }}
           components: rustfmt, clippy
           # By default, setup-rust-toolchain sets "-D warnings". As a side effect, the settings in
           # .cargo/config.toml are ignored:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,11 +1,5 @@
-# The channel and the targets defined here are taken into account by
-# actions-rust-lang/setup-rust-toolchain when setting up the CI environment.
+# The channel defined here is taken into account by actions-rust-lang/setup-rust-toolchain when
+# setting up the CI environment.
 
 [toolchain]
 channel = "1.83"
-
-[toolchain.linux]
-targets = ["x86_64-unknown-linux-gnu"]
-
-[toolchain.windows]
-targets = ["x86_64-pc-windows-msvc"]


### PR DESCRIPTION
The documentation of `actions-rust-lang/setup-rust-toolchain` says: "First, all items specified in the toolchain file are installed. Afterward, the components and target specified via inputs are installed in addition to the items from the toolchain file."

However, this does not seem to be the case. The targets specified in `rust-toolchain.toml` are apparently ignored. This makes not difference in the 2.0 branch, since we use the default Linux/Windows targets. But in 3.0 and main, we want to use `x86_64-unknown-linux-musl`, which is not the default Linux target. Specifying this target in `rust-toolchain.toml` does not make `actions-rust-lang/setup-rust-toolchain` install it, which is how this problem became apparent.

Even though we are currently using the default Linux/Windows targets, we still specify them in the Rust setup step for the sake of explicitness.