### PR TITLE
Increase timeout in `test_rebot_run` system test

### DIFF
--- a/tests/test_plan_run.rs
+++ b/tests/test_plan_run.rs
@@ -25,7 +25,7 @@ fn test_rebot_run() -> AnyhowResult<()> {
         "test",
         &Environment::System(SystemEnvironment {}),
         &Session::Current(CurrentSession {}),
-        3,
+        10,
         &CancellationToken::default(),
         &test_dir,
     )?;


### PR DESCRIPTION
3 seconds should be sufficient in most cases. However, we have observed one CI run with a timeout in this test, so we increase to 10 seconds.