### PR TITLE
Fix issues with latest Clippy version

### DIFF
--- a/src/bin/agent_plugin.rs
+++ b/src/bin/agent_plugin.rs
@@ -47,9 +47,9 @@ fn print_sections(sections: &[Section], stdout: &mut impl io::Write) {
     for section in sections.iter() {
         let mut with_header = format!("<<<{}:sep(0)>>>\n{}\n", section.name, section.content);
         if let Host::Piggyback(host) = &section.host {
-            with_header = format!("<<<<{}>>>>\n{}<<<<>>>>\n", host, with_header);
+            with_header = format!("<<<<{host}>>>>\n{with_header}<<<<>>>>\n");
         }
-        write!(stdout, "{}", with_header).unwrap();
+        write!(stdout, "{with_header}").unwrap();
     }
 }
 

--- a/src/bin/scheduler/scheduling/cleanup.rs
+++ b/src/bin/scheduler/scheduling/cleanup.rs
@@ -35,7 +35,7 @@ fn cleanup_working_directory(
         .read_dir_utf8()?
         .filter_map(|dir_entry_result| {
             dir_entry_result
-                .context(format!("Failed to list entry of directory {}", directory))
+                .context(format!("Failed to list entry of directory {directory}"))
                 .map_err(log_and_return_error)
                 .ok()
         })

--- a/src/bin/scheduler/scheduling/plans.rs
+++ b/src/bin/scheduler/scheduling/plans.rs
@@ -56,8 +56,7 @@ fn produce_plan_results(plan: &Plan) -> Result<PlanExecutionReport, Terminate> {
         .join(timestamp.format(TIMESTAMP_FORMAT).to_string());
 
     create_dir_all(&output_directory).context(format!(
-        "Failed to create directory for plan run: {}",
-        output_directory
+        "Failed to create directory for plan run: {output_directory}"
     ))?;
 
     let (attempt_reports, rebot) = run_attempts_with_rebot(

--- a/src/command_spec.rs
+++ b/src/command_spec.rs
@@ -99,7 +99,7 @@ impl CommandSpec {
     pub fn to_command_string(&self) -> String {
         let mut command = Command::new(self.executable.clone());
         command.args(&self.arguments);
-        format!("{:?}", command)
+        format!("{command:?}")
     }
 }
 

--- a/src/rf/robot.rs
+++ b/src/rf/robot.rs
@@ -48,7 +48,7 @@ impl Robot {
     }
 
     fn attempt(&self, output_directory: &Utf8Path, index: usize) -> Attempt {
-        let output_xml_file = output_directory.join(format!("{}.xml", index));
+        let output_xml_file = output_directory.join(format!("{index}.xml"));
         Attempt {
             index,
             command_spec: self.command_spec(output_directory, &output_xml_file, index),
@@ -76,7 +76,7 @@ impl Robot {
             .add_argument("--output")
             .add_argument(output_xml_file)
             .add_argument("--log")
-            .add_argument(output_directory.join(format!("{}.html", index)))
+            .add_argument(output_directory.join(format!("{index}.html")))
             .add_argument("--report")
             .add_argument("NONE")
             .add_argument(&self.robot_target);

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,8 +48,8 @@ impl Session {
 impl Display for Session {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::Current(current_session) => write!(f, "{}", current_session),
-            Self::User(user_session) => write!(f, "{}", user_session),
+            Self::Current(current_session) => write!(f, "{current_session}"),
+            Self::User(user_session) => write!(f, "{user_session}"),
         }
     }
 }

--- a/src/tasks/windows.rs
+++ b/src/tasks/windows.rs
@@ -45,7 +45,7 @@ pub fn run_task(task_spec: &TaskSpec) -> AnyhowResult<Outcome<i32>> {
     let _ = task_manager
         .delete_task(&task)
         .context(format!("Failed to delete task {}", task_spec.task_name))
-        .map_err(|e| error!("{:?}", e));
+        .map_err(|e| error!("{e:?}"));
 
     match outcome {
         Outcome::Cancel => return Ok(Outcome::Cancel),
@@ -189,7 +189,7 @@ impl TaskManager {
     ) -> WinApiResult<Outcome<WinApiResult<()>>> {
         let (name, running_task) = unsafe {
             let name = task.Name()?;
-            debug!("Starting task {}", name);
+            debug!("Starting task {name}");
             (name, task.Run(&VARIANT::default())?)
         };
         debug!("Waiting for task {name} to complete");
@@ -200,7 +200,7 @@ impl TaskManager {
         )
         .await;
         if !matches!(outcome, Outcome::Completed(Ok(_))) {
-            error!("Killing task {}", name);
+            error!("Killing task {name}");
             let _ = self.kill_task(&running_task);
         }
         Ok(outcome)
@@ -275,8 +275,7 @@ fn read_exit_code(path: &Utf8Path) -> AnyhowResult<i32> {
         .context(format!("{path} is empty"))?
         .to_string();
     content_until_first_whitespace.parse().context(format!(
-        "Failed to parse {} as i32",
-        content_until_first_whitespace
+        "Failed to parse {content_until_first_whitespace} as i32"
     ))
 }
 


### PR DESCRIPTION
Apparently, a new check was added:
```
variables can be used directly in the `format!` string
```