### PR TITLE
Change version from 5.0.0-alpha-1 to 4.1.0-alpha-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "robotmk"
-version = "5.0.0-alpha-1"
+version = "4.1.0-alpha-1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robotmk"
-version = "5.0.0-alpha-1"
+version = "4.1.0-alpha-1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
We are not planning any major changes to the scheduler in the foreseeable future, so 4.1.0 is more correct than 5.0.0.